### PR TITLE
Allow multiple values with inclusion validator 

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,7 +24,7 @@ jobs:
       - name: set up ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.1
+          ruby-version: 2.7
 
       - name: Ruby gem cache
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ filter :manager_id, association: :department
 If the filter value should be validated, use the `validates` option along with [ActiveModel validations](https://api.rubyonrails.org/classes/ActiveModel/Validations/ClassMethods.html#method-i-validates). Here's an example of the inclusion validator being used to restrict sizes:
 
 ```ruby
-filter :size, validates: { inclusion: { in: %w[Small Medium Large] }, unless: -> { size.is_a? Array } }
+filter :size, validates: { inclusion: { in: %w[Small Medium Large] } }
 ```
 
-Note that the `inclusion` validator does not allow arrays to be specified. If the filter should allow multiple values to be specified, then the validation needs to be disabled when the value an array.
+The `inclusion` validator has been overridden to provide the additional option `allow_multiple_values`. When true, the value can be an array and each entry in the array will be validated. Use this when the filter can specify one or more values.
+
+```ruby
+filter :size, validates: { inclusion: { in: %w[Small Medium Large], allow_multiple_values: true } }
+```
+
 
 #### partial
 Specify the partial option if the filter should do a partial search (SQL's `LIKE`). The partial option accepts a hash to specify the search behavior. Here are the available options:

--- a/lib/filterameter/parameters_base.rb
+++ b/lib/filterameter/parameters_base.rb
@@ -2,6 +2,7 @@
 
 require 'active_model/attribute_assignment'
 require 'active_model/validations'
+require 'filterameter/validators/inclusion_validator'
 
 module Filterameter
   # = Parameters
@@ -9,6 +10,7 @@ module Filterameter
   # Class Parameters is sub-classed to provide controller-specific validations.
   class ParametersBase
     include ActiveModel::Validations
+    include Filterameter::Validators
 
     def self.build_sub_class(declarations)
       Class.new(self).tap do |sub_class|

--- a/lib/filterameter/validators/inclusion_validator.rb
+++ b/lib/filterameter/validators/inclusion_validator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module Validators
+    # = Inclusion Validator
+    #
+    # Class InclusionValidator extends ActiveModel::Validations::InclusionValidator to enable validations of multiple
+    # values.
+    #
+    # == Example
+    #
+    #   validates: { inclusion: { in: %w[Small Medium Large], allow_multiple_values: true } }
+    #
+    class InclusionValidator < ActiveModel::Validations::InclusionValidator
+      def validate_each(record, attribute, value)
+        return super unless allow_multiple_values?
+
+        # any? just provides a mechanism to stop after first error
+        Array.wrap(value).any? { |v| super(record, attribute, v) }
+      end
+
+      private
+
+      def allow_multiple_values?
+        @options.fetch(:allow_multiple_values, false)
+      end
+    end
+  end
+end

--- a/spec/controllers/shirts_controller_spec.rb
+++ b/spec/controllers/shirts_controller_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe ShirtsController, type: :controller do
     it { expect(response_body.size).to eq count }
   end
 
+  shared_examples 'raises ValidationError' do |message|
+    it do
+      expect { request }
+        .to raise_error(Filterameter::Exceptions::ValidationError,
+                        "The following parameter(s) failed validation: #{message}")
+    end
+  end
+
   describe 'with no filters' do
     before { get :index }
 
@@ -142,10 +150,13 @@ RSpec.describe ShirtsController, type: :controller do
     let(:filter) { { size: 'Extra Large' } }
     let(:request) { get :index, params: { filter: filter } }
 
-    it 'raises ValidationError' do
-      expect { request }
-        .to raise_error(Filterameter::Exceptions::ValidationError,
-                        'The following parameter(s) failed validation: ["Size is not included in the list"]')
-    end
+    it_behaves_like 'raises ValidationError', '["Size is not included in the list"]'
+  end
+
+  context 'with array of values that has an invalid value' do
+    let(:filter) { { size: %w[Medium Large Big] } }
+    let(:request) { get :index, params: { filter: filter } }
+
+    it_behaves_like 'raises ValidationError', '["Size is not included in the list"]'
   end
 end

--- a/spec/dummy/app/controllers/shirts_controller.rb
+++ b/spec/dummy/app/controllers/shirts_controller.rb
@@ -5,7 +5,7 @@ class ShirtsController < ApplicationController
   before_action :build_filtered_query, only: :index
 
   filter :color
-  filter :size, validates: { inclusion: { in: %w[Small Medium Large] }, unless: -> { size.is_a? Array } }
+  filter :size, validates: { inclusion: { in: %w[Small Medium Large], allow_multiple_values: true } }
   filter :brand_name, association: :brand, name: :name
   filter :on_sale, association: :price, validates: [{ numericality: { greater_than: 0 } },
                                                     { numericality: { less_than: 100 } }]

--- a/spec/filterameter/validators/inclusion_validator_spec.rb
+++ b/spec/filterameter/validators/inclusion_validator_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Filterameter::Validators::InclusionValidator do
+  let(:record) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :size
+
+      def self.name
+        'InclusionValidatorTestModel'
+      end
+    end.new
+  end
+
+  shared_examples 'flags attribute as invalid' do
+    it do
+      expect(record.errors).not_to be_empty
+      expect(record.errors).to include(:size)
+      expect(record.errors.full_messages).to contain_exactly('Size is not included in the list')
+    end
+  end
+
+  context 'with single values' do
+    let(:validator) { described_class.new(attributes: %i[size], in: %w[Small Medium Large]) }
+
+    it 'valid with single value' do
+      validator.validate_each(record, :size, 'Small')
+      expect(record.errors).to be_empty
+    end
+
+    context 'with incorrect value' do
+      before { validator.validate_each(record, :size, 'XL') }
+
+      it_behaves_like 'flags attribute as invalid'
+    end
+  end
+
+  context 'with multiple values allowed' do
+    let(:validator) do
+      described_class.new(attributes: %i[size], in: %w[Small Medium Large], allow_multiple_values: true)
+    end
+
+    it 'valid with single value' do
+      validator.validate_each(record, :size, 'Small')
+      expect(record.errors).to be_empty
+    end
+
+    context 'with incorrect value' do
+      before { validator.validate_each(record, :size, 'XL') }
+
+      it_behaves_like 'flags attribute as invalid'
+    end
+
+    it 'valid with two values' do
+      validator.validate_each(record, :size, %w[Small Medium])
+      expect(record.errors).to be_empty
+    end
+
+    context 'with two values when one is wrong' do
+      before { validator.validate_each(record, :size, %w[Large XL]) }
+
+      it_behaves_like 'flags attribute as invalid'
+    end
+
+    context 'with multiple incorrect values' do
+      before { validator.validate_each(record, :size, %w[Large XL XXL XXXL]) }
+
+      it_behaves_like 'flags attribute as invalid'
+    end
+  end
+end


### PR DESCRIPTION
Override the inclusion validator to provide new option :allow_multiple_options. When specified, the filter can optionally specify an array of values and each value will be validated.