### PR TITLE
Fix ranges

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,7 +14,6 @@ jobs:
           - rails_6
           - rails_6_1
           - rails_7
-          - rails_master
         exclude:
           - ruby: '3.0'
             gemfile: 'rails_5_2'

--- a/Appraisals
+++ b/Appraisals
@@ -15,7 +15,3 @@ end
 appraise 'rails-7' do
   gem 'rails', '~> 7.0.0'
 end
-
-appraise 'rails-master' do
-  gem 'rails', github: 'rails/rails', branch: 'main'
-end

--- a/lib/filterameter/filter_registry.rb
+++ b/lib/filterameter/filter_registry.rb
@@ -16,13 +16,14 @@ module Filterameter
     end
 
     def add_filter(parameter_name, options)
-      @declarations[parameter_name.to_s] = Filterameter::FilterDeclaration.new(parameter_name, options).tap do |fd|
-        add_declarations_for_range(fd, options, parameter_name) if fd.range_enabled?
+      name = parameter_name.to_s
+      @declarations[name] = Filterameter::FilterDeclaration.new(name, options).tap do |fd|
+        add_declarations_for_range(fd, options, name) if fd.range_enabled?
       end
     end
 
-    def fetch(name)
-      name = name.to_s
+    def fetch(parameter_name)
+      name = parameter_name.to_s
       @filters.fetch(name) do
         raise Filterameter::Exceptions::UndeclaredParameterError, name unless @declarations.keys.include?(name)
 

--- a/lib/filterameter/query_builder.rb
+++ b/lib/filterameter/query_builder.rb
@@ -11,7 +11,7 @@ module Filterameter
     end
 
     def build_query(filter_params, starting_query = nil)
-      valid_filters(filter_params)
+      valid_filters(filter_params.stringify_keys)
         .tap { |parameters| convert_min_and_max_to_range(parameters) }
         .reduce(starting_query || @default_query) do |query, (name, value)|
         add_filter_parameter_to_query(query, name, value)

--- a/spec/dummy/app/queries/string_key_query.rb
+++ b/spec/dummy/app/queries/string_key_query.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# = String Key Query
+#
+# Class StringKeyQuery builds a query using strings as keys.
+class StringKeyQuery
+  include Filterameter::DeclarativeFilters
+
+  model 'Shirt'
+
+  filter 'color'
+  filter 'size', validates: { inclusion: { in: %w[Small Medium Large], allow_multiple_values: true } }
+  filter 'brand_name', association: :brand, name: :name
+  filter 'on_sale', association: :price, validates: [{ numericality: { greater_than: 0 } },
+                                                     { numericality: { less_than: 100 } }]
+  filter 'color_type_ahead', name: :color, partial: { match: :from_start }
+  filter 'fuzzy_color', name: :color, partial: true
+  filter 'color_client_search', name: :color, partial: { match: :dynamic }
+  filter 'case_sensitive_color', name: :color, partial: { case_sensitive: true }
+  filter 'price', name: :current, association: :price, range: true
+end

--- a/spec/fixtures/prices.yml
+++ b/spec/fixtures/prices.yml
@@ -14,7 +14,8 @@ blue_medium:
   <<: *blue_shirt
 blue_large:
   shirt: blue_large
-  <<: *blue_shirt
+  current: 20.99
+  original: 25.99
 
 gold_small:
   shirt: gold_small
@@ -24,4 +25,5 @@ gold_medium:
   <<: *gold_shirt
 gold_large:
   shirt: gold_medium
-  <<: *gold_shirt
+  current: 25.99
+  original: 25.99

--- a/spec/queries/string_key_query_spec.rb
+++ b/spec/queries/string_key_query_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/shared_examples_for_shirts'
+
+RSpec.describe StringKeyQuery do
+  fixtures :shirts
+
+  let(:filter) { {} }
+  let(:starting_query) { nil }
+  let(:query) { described_class.build_query(filter, starting_query) }
+
+  shared_examples 'count is correct' do |count|
+    it { expect(query.count).to eq count }
+  end
+
+  shared_examples 'raises ValidationError' do |message|
+    it do
+      expect { query.take }
+        .to raise_error(Filterameter::Exceptions::ValidationError,
+                        "The following parameter(s) failed validation: #{message}")
+    end
+  end
+
+  it_behaves_like 'applies filter parameters'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,6 @@ RSpec.configure do |config|
 
   config.default_formatter = 'doc' if config.files_to_run.one?
 
-  config.profile_examples = 10
-
   config.order = :random
   Kernel.srand config.seed
 end

--- a/spec/support/shared_examples_for_shirts.rb
+++ b/spec/support/shared_examples_for_shirts.rb
@@ -76,8 +76,8 @@ RSpec.shared_examples 'applies filter parameters' do
     describe 'price range' do
       fixtures :prices
 
-      context 'from 11.99 - 21.99' do
-        let(:filter) { { price_min: 11.99, price_max: 21.99 } }
+      context 'from 20.00 - 25.00' do
+        let(:filter) { { price_min: 20.00, price_max: 25.00 } }
 
         it_behaves_like 'count is correct', 3
       end
@@ -91,13 +91,13 @@ RSpec.shared_examples 'applies filter parameters' do
       context 'up to 19.99' do
         let(:filter) { { price_max: 19.99 } }
 
-        it_behaves_like 'count is correct', 3
+        it_behaves_like 'count is correct', 2
       end
 
       context 'attribute filter still works' do
         let(:filter) { { price: 19.99 } }
 
-        it_behaves_like 'count is correct', 3
+        it_behaves_like 'count is correct', 2
       end
     end
   end


### PR DESCRIPTION
The code to identify range criteria and convert the parameters was comparing strings and symbols in some cases and not finding a match. The filter registry has been updated to always use strings, and the query builder converts the criteria to string keys.