### PR TITLE
Add script to start test database

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,7 +18,7 @@ jobs:
       BUNDLE_PATH_RELATIVE_TO_CWD: true
     services:
       db:
-        image: postgres:11
+        image: postgres:16
         env:
           POSTGRES_USER: filterameter
           POSTGRES_DB: filterameter_test

--- a/README.md
+++ b/README.md
@@ -173,19 +173,19 @@ $ gem install filterameter
 
 ## Running Tests
 
-Tests are written in RSpec and the dummy app uses a docker database. First, start the database and prepare it from the dummy folder.
+Tests are written in RSpec and the dummy app uses a docker database. The script `bin/start_db.sh` starts and prepares the test
+database. It is a one-time step before running the tests.
 
 ```bash
-cd spec/dummy
-docker-compose up -d
-bundle exec rails db:test:prepare
-cd ../..
+bin/start_db.rb
+bundle exec rspec
 ```
 
-Run the tests from the main directory
+The tests can also be run across all the ruby and Rails combinations using appraisal. The install is also a one-time step.
 
 ```bash
-bundle exec rspec
+bundle exec appraisal install
+bundle exec appraisal rspec
 ```
 
 ## License

--- a/bin/start_db.sh
+++ b/bin/start_db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd spec/dummy
+docker compose up -d
+bundle exec rails db:test:prepare

--- a/spec/dummy/docker-compose.yml
+++ b/spec/dummy/docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3'
 services:
   db:
     container_name: filterameter_db
-    image: postgres:11
+    image: postgres:16
     environment:
       - POSTGRES_USER=filterameter
       - POSTGRES_DB=filterameter


### PR DESCRIPTION
- script bin/start_db.sh wraps the docker compose command and the db:test:preapre task
- upgrade the postgres database from 11 to 16
- added instructions for running tests across versions with appraisal