### PR TITLE
Support collection association filters

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -23,7 +23,7 @@ guard :rspec, cmd: 'bundle exec rspec' do
   watch('spec/dummy/app/controllers/application_controller.rb') { "#{rspec.spec_dir}/controllers" }
 end
 
-guard :rubocop, cli: %w[--display-cop-names --auto-correct-all] do
+guard :rubocop, cli: %w[--display-cop-names --autocorrect-all] do
   watch(/.+\.rb$/)
   watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
 end

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ filter :status, name: :current_status
 ```
 
 #### association
-If the attribute or scope is nested, it can be referenced by naming the association. Only singular associations are valid. For example, if the manager_id attribute lives on an employee's department record, use the following:
+If the attribute or scope is nested, it can be referenced by naming the association. For example, if the manager_id attribute lives on an employee's department record, use the following:
 
 ```ruby
 filter :manager_id, association: :department
 ```
+
+If the association is a `has_many`, then a sub-query will be used to find matching rows.
 
 #### validates
 If the filter value should be validated, use the `validates` option along with [ActiveModel validations](https://api.rubyonrails.org/classes/ActiveModel/Validations/ClassMethods.html#method-i-validates). Here's an example of the inclusion validator being used to restrict sizes:

--- a/lib/filterameter/filter_factory.rb
+++ b/lib/filterameter/filter_factory.rb
@@ -13,7 +13,11 @@ module Filterameter
       model = declaration.nested? ? model_from_association(declaration.association) : @model_class
       filter = build_filter(model, declaration)
 
-      declaration.nested? ? Filterameter::Filters::NestedFilter.new(declaration.association, model, filter) : filter
+      if declaration.nested?
+        build_nested_filter(model, declaration, filter)
+      else
+        filter
+      end
     end
 
     private
@@ -30,6 +34,15 @@ module Filterameter
         Filterameter::Filters::MaximumFilter.new(model, declaration.name)
       else
         Filterameter::Filters::AttributeFilter.new(declaration.name)
+      end
+    end
+
+    def build_nested_filter(model, declaration, filter)
+      association = @model_class.reflect_on_association(declaration.association)
+      if association.collection?
+        Filterameter::Filters::NestedCollectionFilter.new(association.foreign_key, model, filter)
+      else
+        Filterameter::Filters::NestedFilter.new(declaration.association, model, filter)
       end
     end
 

--- a/lib/filterameter/filter_registry.rb
+++ b/lib/filterameter/filter_registry.rb
@@ -51,8 +51,8 @@ module Filterameter
     end
 
     def add_range_maximum(parameter_name, options)
-      parameter_name_min = "#{parameter_name}_max"
-      @declarations[parameter_name_min] = Filterameter::FilterDeclaration.new(parameter_name_min,
+      parameter_name_max = "#{parameter_name}_max"
+      @declarations[parameter_name_max] = Filterameter::FilterDeclaration.new(parameter_name_max,
                                                                               options.merge(range: :max_only))
     end
 

--- a/lib/filterameter/filters/nested_collection_filter.rb
+++ b/lib/filterameter/filters/nested_collection_filter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module Filters
+    # = Nested Collection Filter
+    #
+    # Class NestedCollectionFilter uses a sub-query to find matching rows in the collection association.
+    #
+    # For example, if a Brand has many Shirts, the following SQL is generated:
+    #
+    #   SELECT "brands".*
+    #   FROM "brands"
+    #   WHERE "brands"."id" IN (
+    #     SELECT "shirts"."brand_id" FROM "shirts" WHERE "shirts"."color" = 'blue'
+    #   )
+    class NestedCollectionFilter
+      def initialize(foreign_key, association_model, attribute_filter)
+        @foreign_key = foreign_key
+        @association_model = association_model
+        @attribute_filter = attribute_filter
+      end
+
+      def apply(query, value)
+        sub_query = @attribute_filter.apply(@association_model, value)
+        query.where(id: sub_query.select(@foreign_key).distinct)
+      end
+    end
+  end
+end

--- a/spec/dummy/app/queries/brands_query.rb
+++ b/spec/dummy/app/queries/brands_query.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# = Brands Query
+#
+# Class BrandsQuery builds a query based on the declared the filter parameters.
+class BrandsQuery
+  include Filterameter::DeclarativeFilters
+
+  model 'Brand'
+
+  filter :color, association: :shirts
+  filter :size, association: :shirts
+end

--- a/spec/filterameter/filter_factory_spec.rb
+++ b/spec/filterameter/filter_factory_spec.rb
@@ -40,4 +40,11 @@ RSpec.describe Filterameter::FilterFactory do
     let(:declaration) { Filterameter::FilterDeclaration.new(:name, { association: :brand }) }
     it('is an NestedFilter') { expect(filter).to be_a Filterameter::Filters::NestedFilter }
   end
+
+  context 'with collection association declaration' do
+    let(:factory) { Filterameter::FilterFactory.new(Brand) }
+
+    let(:declaration) { Filterameter::FilterDeclaration.new(:color, { association: :shirts }) }
+    it('is a NestedCollectionFilter') { expect(filter).to be_a Filterameter::Filters::NestedCollectionFilter }
+  end
 end

--- a/spec/filterameter/filter_factory_spec.rb
+++ b/spec/filterameter/filter_factory_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Filterameter::FilterFactory do
+  let(:factory) { Filterameter::FilterFactory.new(Shirt) }
+  let(:filter) { factory.build(declaration) }
+
+  context 'with attribute declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:size, {}) }
+    it('is an AttributeFilter') { expect(filter).to be_a Filterameter::Filters::AttributeFilter }
+  end
+
+  context 'with scope declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:blue, {}) }
+    it('is a ScopeFilter') { expect(filter).to be_a Filterameter::Filters::ScopeFilter }
+  end
+
+  context 'with partial declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:color, { partial: true }) }
+    it('is a MatchesFilter') { expect(filter).to be_a Filterameter::Filters::MatchesFilter }
+  end
+
+  context 'with minimum declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:size_min, { range: :min_only }) }
+    it('is a MinimumFilter') { expect(filter).to be_a Filterameter::Filters::MinimumFilter }
+  end
+
+  context 'with maximum declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:size_max, { range: :max_only }) }
+    it('is a MaximumFilter') { expect(filter).to be_a Filterameter::Filters::MaximumFilter }
+  end
+
+  context 'with range declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:size, { range: true }) }
+    it('is an AttributeFilter') { expect(filter).to be_a Filterameter::Filters::AttributeFilter }
+  end
+
+  context 'with singular association declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:name, { association: :brand }) }
+    it('is an NestedFilter') { expect(filter).to be_a Filterameter::Filters::NestedFilter }
+  end
+end

--- a/spec/filterameter/filters/nested_collection_filter_spec.rb
+++ b/spec/filterameter/filters/nested_collection_filter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Filterameter::Filters::NestedCollectionFilter do
+  let(:filter) { described_class.new(:brand_id, Shirt, Filterameter::Filters::AttributeFilter.new(:color)) }
+  let(:result) { filter.apply(Brand.all, 'Blue') }
+
+  it 'generates valid sql' do
+    expect { result.explain }.not_to raise_exception
+  end
+
+  it 'includes sub-query' do
+    sub_query = Shirt.where(color: 'Blue').select(:brand_id).distinct.to_sql
+    expect(result.to_sql).to include sub_query
+  end
+end

--- a/spec/queries/brands_query_spec.rb
+++ b/spec/queries/brands_query_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BrandsQuery do
+  fixtures :brands
+
+  context 'when looking for brands with blue shirts' do
+    let(:query) { described_class.build_query({ color: 'Blue' }, nil) }
+
+    it { expect(query.count).to eq 1 }
+    it('finds Happy Shirts') { expect(query.first.name).to eq 'Happy Shirts' }
+  end
+
+  context 'when looking for brands with large shirts' do
+    let(:query) { described_class.build_query({ size: 'Large' }, nil) }
+
+    it { expect(query.count).to eq 2 }
+  end
+end


### PR DESCRIPTION
Add new NestedCollectionFilter to support querying against has many associations. The new filter generates a sub-query against the association.

The filter factory uses the association definition to determine if it is a singular or collection association.