### PR TITLE
Retire support for Rails pre-6.1 errors

### DIFF
--- a/lib/filterameter/query_builder.rb
+++ b/lib/filterameter/query_builder.rb
@@ -64,15 +64,7 @@ module Filterameter
         raise Filterameter::Exceptions::ValidationError, validator.errors
       end
 
-      filter_params.except(*invalid_attributes(validator.errors).map(&:to_s))
-    end
-
-    def invalid_attributes(errors)
-      if errors.respond_to? :attribute_names
-        errors.attribute_names
-      else # pre rails 6.1
-        errors.keys
-      end
+      filter_params.except(*validator.errors.attribute_names.map(&:to_s))
     end
 
     def validator_class


### PR DESCRIPTION
With the switch to ActiveModel::Error in Rails 6.1, the hash-based access can be retired.

Reference:
https://github.com/rails/rails/pull/32313