### PR TITLE
Switch scope filters to use public send instead of send

### DIFF
--- a/lib/filterameter/filters/conditional_scope_filter.rb
+++ b/lib/filterameter/filters/conditional_scope_filter.rb
@@ -13,7 +13,7 @@ module Filterameter
       def apply(query, value)
         return query unless ActiveModel::Type::Boolean.new.cast(value)
 
-        query.send(@scope_name)
+        query.public_send(@scope_name)
       end
     end
   end

--- a/lib/filterameter/filters/scope_filter.rb
+++ b/lib/filterameter/filters/scope_filter.rb
@@ -11,7 +11,7 @@ module Filterameter
       end
 
       def apply(query, value)
-        query.send(@scope_name, value)
+        query.public_send(@scope_name, value)
       end
     end
   end


### PR DESCRIPTION
The filter factory would not build a scope filter for a private method, but this more formally closes the door to private class methods by switch to public_send.