### PR TITLE
Version 0.5.0: Retire Query Classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    filterameter (0.4.2)
+    filterameter (0.5.0)
       rails (>= 6.1)
 
 GEM

--- a/lib/filterameter/version.rb
+++ b/lib/filterameter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Filterameter
-  VERSION = '0.4.2'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
This is a breaking change: the mixin for controllers was renamed from Filterameter::DeclarativeControllerFilters to Filterameter::DeclarativeFilters. All references must be updated.

Why retire query classes? The goal of Filterameter is to simplify Rails controllers. Extending the functionality to query classes did not add much value and muddied the purpose of the gem.