### PR TITLE
Fix range bug

### DIFF
--- a/lib/filterameter/filter_registry.rb
+++ b/lib/filterameter/filter_registry.rb
@@ -46,14 +46,16 @@ module Filterameter
 
     def add_range_minimum(parameter_name, options)
       parameter_name_min = "#{parameter_name}_min"
-      @declarations[parameter_name_min] = Filterameter::FilterDeclaration.new(parameter_name_min,
-                                                                              options.merge(range: :min_only))
+      options_with_range = options.with_defaults(name: parameter_name)
+                                  .merge(range: :min_only)
+      @declarations[parameter_name_min] = Filterameter::FilterDeclaration.new(parameter_name_min, options_with_range)
     end
 
     def add_range_maximum(parameter_name, options)
       parameter_name_max = "#{parameter_name}_max"
-      @declarations[parameter_name_max] = Filterameter::FilterDeclaration.new(parameter_name_max,
-                                                                              options.merge(range: :max_only))
+      options_with_range = options.with_defaults(name: parameter_name)
+                                  .merge(range: :max_only)
+      @declarations[parameter_name_max] = Filterameter::FilterDeclaration.new(parameter_name_max, options_with_range)
     end
 
     def capture_range_declaration(name)

--- a/spec/filterameter/filter_registry_spec.rb
+++ b/spec/filterameter/filter_registry_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Filterameter::FilterRegistry do
       expect(filter_names).to contain_exactly('date', 'date_min', 'date_max')
     end
 
+    it 'stores ranges filters with correct name' do
+      registry.add_filter(:date, range: true)
+      expect(registry.filter_declarations.map(&:name).uniq).to contain_exactly('date')
+    end
+
     it 'adds min filters' do
       registry.add_filter(:date, range: :min_only)
       expect(filter_names).to contain_exactly('date', 'date_min')
@@ -26,6 +31,18 @@ RSpec.describe Filterameter::FilterRegistry do
     it 'adds max filters' do
       registry.add_filter(:date, range: :max_only)
       expect(filter_names).to contain_exactly('date', 'date_max')
+    end
+
+    context 'with name specified for range filter' do
+      before { registry.add_filter(:date, name: :start_date, range: true) }
+
+      it 'adds range filters' do
+        expect(filter_names).to contain_exactly('date', 'date_min', 'date_max')
+      end
+
+      it 'stores ranges filters with correct attribute name' do
+        expect(registry.filter_declarations.map(&:name).uniq).to contain_exactly('start_date')
+      end
     end
   end
 


### PR DESCRIPTION
If a range filter does not use the name option, the min and max filters incorrectly use the range suffix. Only the parameter name should have the suffix. This causes the query to try to generate criteria using the parameter name instead of the attribute name.