### PR TITLE
Support conditional scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ filter :sale_price, range: :max_only
 
 In the first example, query parameters could include <tt>price</tt>, <tt>price_min</tt>, and <tt>price_max</tt>.
 
+### Scope Filters
+
+For scopes that do not take arguments, the filter should provide a boolean that indicates whether or not the scope should be invoked. For example, imagine a scope called `high_priority` with criteria that identifies high priority records. The scope would be invoked by the query parameters `high_priority=true`.
+
+Passing `high_priority=false` will not invoke the scope. This makes it easy to include a filter with a check box UI.
+
+Scopes that do take arguments [must be written as class methods, not inline scopes.](https://guides.rubyonrails.org/active_record_querying.html#passing-in-arguments) For example, imagine a scope called `recent` that takes an as of date as an argument. Here is what that might look like:
+
+```ruby
+def self.recent(as_of_date)
+  where('created_at > ?', as_of_date)
+end
+```
+
 ### Controllers
 
 Include module `Filterameter::DeclarativeFilters` in the controller. Add before action callback `build_filtered_query` for controller actions that should build the query.

--- a/spec/filterameter/filter_factory_spec.rb
+++ b/spec/filterameter/filter_factory_spec.rb
@@ -12,8 +12,14 @@ RSpec.describe Filterameter::FilterFactory do
   end
 
   context 'with scope declaration' do
-    let(:declaration) { Filterameter::FilterDeclaration.new(:blue, {}) }
+    let(:factory) { Filterameter::FilterFactory.new(Price) }
+    let(:declaration) { Filterameter::FilterDeclaration.new(:percent_reduced, {}) }
     it('is a ScopeFilter') { expect(filter).to be_a Filterameter::Filters::ScopeFilter }
+  end
+
+  context 'with conditional scope declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:blue, {}) }
+    it('is a ConditionalScopeFilter') { expect(filter).to be_a Filterameter::Filters::ConditionalScopeFilter }
   end
 
   context 'with partial declaration' do


### PR DESCRIPTION
Use the arity of the scope to determine wether or not it should receive a value. An inline scope without any arguments is treated as a conditional scope: It will not be run if the parameter value is false.

A class method must be used (instead of an inline scope) to define a scope that takes an argument. (That's the only way to be able to tell it has a single parameter).