### PR TITLE
Add method build_query_from_filters

### DIFF
--- a/lib/filterameter/declarative_filters.rb
+++ b/lib/filterameter/declarative_filters.rb
@@ -3,7 +3,7 @@
 module Filterameter
   # = Declarative Controller Filters
   #
-  # Mixin DeclarativeFilters can included in controllers to enable the filter DSL.
+  # Mixin DeclarativeFilters should be included in controllers to enable the filter DSL.
   module DeclarativeFilters
     extend ActiveSupport::Concern
     include Filterameter::Filterable
@@ -23,15 +23,20 @@ module Filterameter
       end
     end
 
+    def build_query_from_filters(starting_query = nil)
+      self.class.filter_coordinator.build_query(filter_parameters, starting_query)
+    end
+
+    def filter_parameters
+      params.to_unsafe_h.fetch(:filter, {})
+    end
+
     private
 
     def build_filtered_query
       var_name = "@#{self.class.filter_coordinator.query_variable_name}"
-      instance_variable_set(
-        var_name,
-        self.class.filter_coordinator.build_query(params.to_unsafe_h.fetch(:filter, {}),
-                                                  instance_variable_get(var_name))
-      )
+      starting_query = instance_variable_get(var_name)
+      instance_variable_set(var_name, build_query_from_filters(starting_query))
     end
   end
 end

--- a/spec/dummy/app/controllers/active_activities_controller.rb
+++ b/spec/dummy/app/controllers/active_activities_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ActiveActivitiesController < ApplicationController
+  filter_model 'Activity'
+  filter :project_id
+
+  def index
+    render json: build_query_from_filters(Activity.incomplete)
+  end
+end

--- a/spec/dummy/app/controllers/active_tasks_controller.rb
+++ b/spec/dummy/app/controllers/active_tasks_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ActiveTasksController < ApplicationController
+  filter_model Task
+  filters :activity_id, :completed
+
+  def index
+    @tasks = build_query_from_filters
+
+    render json: @tasks
+  end
+
+  private
+
+  def filter_parameters
+    super.merge(completed: false)
+  end
+end

--- a/spec/dummy/app/controllers/activities_controller.rb
+++ b/spec/dummy/app/controllers/activities_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ActivitiesController < ApplicationController
+  before_action :build_filtered_query, only: :index
+
   filter :activity_manager_id
   filter :manager_id, name: :activity_manager_id
   filter :incomplete
@@ -14,8 +16,6 @@ class ActivitiesController < ApplicationController
   filter :incomplete_tasks, name: :incomplete, association: :tasks
 
   def index
-    activities = build_query
-
-    render json: activities
+    render json: @activities
   end
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -2,10 +2,4 @@
 
 class ApplicationController < ActionController::API
   include Filterameter::DeclarativeFilters
-
-  private
-
-  def build_query
-    self.class.filter_coordinator.build_query(params.to_unsafe_h.fetch(:filter, {}))
-  end
 end

--- a/spec/dummy/app/controllers/legacy_projects_controller.rb
+++ b/spec/dummy/app/controllers/legacy_projects_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class LegacyProjectsController < ApplicationController
+  filter_model Project
+  filter :priority, validates: { inclusion: { in: Project.priorities.keys } }
+
+  def index
+    @projects = build_query_from_filters
+
+    render json: @projects
+  end
+
+  private
+
+  def filter_parameters
+    params.to_unsafe_h.fetch(:criteria, {})
+  end
+end

--- a/spec/dummy/app/controllers/projects_controller.rb
+++ b/spec/dummy/app/controllers/projects_controller.rb
@@ -9,7 +9,7 @@ class ProjectsController < ApplicationController
   filter :in_progress
 
   def index
-    @projects = build_query
+    @projects = build_query_from_filters
 
     render json: @projects
   end

--- a/spec/dummy/app/controllers/tasks_controller.rb
+++ b/spec/dummy/app/controllers/tasks_controller.rb
@@ -13,7 +13,7 @@ class TasksController < ApplicationController
   filter :with_inactive_activity_member, name: :inactive, association: %i[activity activity_members]
 
   def index
-    @tasks = build_query
+    @tasks = build_query_from_filters
 
     render json: @tasks
   end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,4 +2,8 @@ Rails.application.routes.draw do
   resources :tasks, only: :index
   resources :activities, only: :index
   resources :projects, only: :index
+
+  resources :legacy_projects, only: :index
+  resources :active_activities, only: :index
+  resources :active_tasks, only: :index
 end

--- a/spec/requests/controller_overrides_spec.rb
+++ b/spec/requests/controller_overrides_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Controller overrides', type: :request do
+  fixtures :projects, :activities
+
+  context 'with nested key overridden' do
+    before { get '/legacy_projects', params: { criteria: { priority: 'high' } } }
+
+    it 'returns the correct number of rows' do
+      count = Project.high_priority.count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'high priority projects include Start day on the right foot' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('name' => projects(:start_day).name)
+    end
+  end
+
+  context 'with starting query' do
+    before { get '/active_activities', params: { filter: { project_id: projects(:start_day).id } } }
+
+    it 'returns the correct number of rows' do
+      count = Activity.where(completed: false, project_id: projects(:start_day).id).count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'active activities on Start Day project include Good Breakfast' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('name' => activities(:good_breakfast).name)
+    end
+  end
+
+  context 'with filter_parameters overridden' do
+    fixtures :tasks
+
+    before { get '/active_tasks', params: { filter: { activity_id: activities(:good_breakfast).id } } }
+
+    it 'returns the correct number of rows' do
+      count = Task.where(completed: false, activity_id: activities(:good_breakfast).id).count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'active tasks on Good Breakfast include Make Toast' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('description' => tasks(:make_toast).description)
+    end
+  end
+end


### PR DESCRIPTION
New method build_query_from_filters provides an easy way to manually build the query. It is an alternative to the callback.

Additionally, this breaks out the logic to dig the filter parameters out of the controller params variable. Method filter_parameters can be overriden to change how the query parameters are selected.