### PR TITLE
Handle min_only and max_only range options

### DIFF
--- a/lib/filterameter/filter_declaration.rb
+++ b/lib/filterameter/filter_declaration.rb
@@ -6,12 +6,19 @@ module Filterameter
   # = Filter Declaration
   #
   # Class FilterDeclaration captures the filter declaration within the controller.
+  #
+  # When the min_only or max_only range option is specified, in addition to the attribute filter which carries that
+  # option, the registry builds a duplicate declaration that also carries the range_type flag (as either :minimum
+  # or :maximum).
+  #
+  # The predicate methods `min_only?` and `max_only?` answer what was declared; the predicate methods `minimum_range?`
+  # and `maximum_range?` answer what type of filter should be built.
   class FilterDeclaration
     VALID_RANGE_OPTIONS = [true, :min_only, :max_only].freeze
 
     attr_reader :name, :parameter_name, :association, :validations
 
-    def initialize(parameter_name, options)
+    def initialize(parameter_name, options, range_type: nil)
       @parameter_name = parameter_name.to_s
 
       validate_options(options)
@@ -21,6 +28,7 @@ module Filterameter
       @validations = Array.wrap(options[:validates])
       @raw_partial_options = options.fetch(:partial, false)
       @raw_range = options[:range]
+      @range_type = range_type
     end
 
     def nested?
@@ -51,12 +59,20 @@ module Filterameter
       @raw_range == true
     end
 
-    def minimum?
+    def min_only?
       @raw_range == :min_only
     end
 
-    def maximum?
+    def max_only?
       @raw_range == :max_only
+    end
+
+    def minimum_range?
+      @range_type == :minimum
+    end
+
+    def maximum_range?
+      @range_type == :maximum
     end
 
     private

--- a/lib/filterameter/filter_factory.rb
+++ b/lib/filterameter/filter_factory.rb
@@ -33,9 +33,9 @@ module Filterameter
         build_scope_filter(model, declaration)
       elsif declaration.partial_search?
         Filterameter::Filters::MatchesFilter.new(declaration.name, declaration.partial_options)
-      elsif declaration.minimum?
+      elsif declaration.minimum_range?
         Filterameter::Filters::MinimumFilter.new(model, declaration.name)
-      elsif declaration.maximum?
+      elsif declaration.maximum_range?
         Filterameter::Filters::MaximumFilter.new(model, declaration.name)
       else
         Filterameter::Filters::AttributeFilter.new(declaration.name)

--- a/lib/filterameter/filter_registry.rb
+++ b/lib/filterameter/filter_registry.rb
@@ -39,23 +39,25 @@ module Filterameter
 
     # if range is enabled, then in addition to the attribute filter this also adds min and/or max filters
     def add_declarations_for_range(attribute_declaration, options, parameter_name)
-      add_range_minimum(parameter_name, options) if attribute_declaration.range? || attribute_declaration.minimum?
-      add_range_maximum(parameter_name, options) if attribute_declaration.range? || attribute_declaration.maximum?
+      add_range_minimum(parameter_name, options) if attribute_declaration.range? || attribute_declaration.min_only?
+      add_range_maximum(parameter_name, options) if attribute_declaration.range? || attribute_declaration.max_only?
       capture_range_declaration(parameter_name) if attribute_declaration.range?
     end
 
     def add_range_minimum(parameter_name, options)
       parameter_name_min = "#{parameter_name}_min"
-      options_with_range = options.with_defaults(name: parameter_name)
-                                  .merge(range: :min_only)
-      @declarations[parameter_name_min] = Filterameter::FilterDeclaration.new(parameter_name_min, options_with_range)
+      options_with_name = options.with_defaults(name: parameter_name)
+      @declarations[parameter_name_min] = Filterameter::FilterDeclaration.new(parameter_name_min,
+                                                                              options_with_name,
+                                                                              range_type: :minimum)
     end
 
     def add_range_maximum(parameter_name, options)
       parameter_name_max = "#{parameter_name}_max"
-      options_with_range = options.with_defaults(name: parameter_name)
-                                  .merge(range: :max_only)
-      @declarations[parameter_name_max] = Filterameter::FilterDeclaration.new(parameter_name_max, options_with_range)
+      options_with_name = options.with_defaults(name: parameter_name)
+      @declarations[parameter_name_max] = Filterameter::FilterDeclaration.new(parameter_name_max,
+                                                                              options_with_name,
+                                                                              range_type: :maximum)
     end
 
     def capture_range_declaration(name)

--- a/spec/filterameter/filter_declaration_spec.rb
+++ b/spec/filterameter/filter_declaration_spec.rb
@@ -56,7 +56,17 @@ RSpec.describe Filterameter::FilterDeclaration do
 
     it('#range_enabled?') { expect(declaration.range_enabled?).to be true }
     it('#range?') { expect(declaration.range?).to be false }
-    it('#minimum?') { expect(declaration.minimum?).to be true }
+    it('#min_only?') { expect(declaration.min_only?).to be true }
+    it('#minimum_range?') { expect(declaration.minimum_range?).to be false }
+  end
+
+  context 'with range: :min_only and range_type: :minimum' do
+    let(:declaration) { described_class.new(:size, { range: :min_only }, range_type: :minimum) }
+
+    it('#range_enabled?') { expect(declaration.range_enabled?).to be true }
+    it('#range?') { expect(declaration.range?).to be false }
+    it('#min_only?') { expect(declaration.min_only?).to be true }
+    it('#minimum_range?') { expect(declaration.minimum_range?).to be true }
   end
 
   context 'with range: :max_only' do
@@ -64,7 +74,17 @@ RSpec.describe Filterameter::FilterDeclaration do
 
     it('#range_enabled?') { expect(declaration.range_enabled?).to be true }
     it('#range?') { expect(declaration.range?).to be false }
-    it('#maximum?') { expect(declaration.maximum?).to be true }
+    it('#max_only?') { expect(declaration.max_only?).to be true }
+    it('#maximum_range?') { expect(declaration.maximum_range?).to be false }
+  end
+
+  context 'with range: :max_only and range_type: :maximum' do
+    let(:declaration) { described_class.new(:size, { range: :max_only }, range_type: :maximum) }
+
+    it('#range_enabled?') { expect(declaration.range_enabled?).to be true }
+    it('#range?') { expect(declaration.range?).to be false }
+    it('#max_only?') { expect(declaration.max_only?).to be true }
+    it('#maximum_range?') { expect(declaration.maximum_range?).to be true }
   end
 
   context 'with invalid range' do

--- a/spec/filterameter/filter_factory_spec.rb
+++ b/spec/filterameter/filter_factory_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Filterameter::FilterFactory do
   end
 
   context 'with minimum declaration' do
-    let(:declaration) { Filterameter::FilterDeclaration.new(:priority_min, { range: :min_only }) }
+    let(:declaration) { Filterameter::FilterDeclaration.new(:priority_min, { range: :min_only }, range_type: :minimum) }
     it('is a MinimumFilter') { expect(filter).to be_a Filterameter::Filters::MinimumFilter }
   end
 
   context 'with maximum declaration' do
-    let(:declaration) { Filterameter::FilterDeclaration.new(:priority_max, { range: :max_only }) }
+    let(:declaration) { Filterameter::FilterDeclaration.new(:priority_max, { range: :max_only }, range_type: :maximum) }
     it('is a MaximumFilter') { expect(filter).to be_a Filterameter::Filters::MaximumFilter }
   end
 

--- a/spec/filterameter/filter_registry_spec.rb
+++ b/spec/filterameter/filter_registry_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Filterameter::FilterRegistry do
   describe '#add_filter' do
-    let(:registry) { described_class.new(instance_spy(Filterameter::FilterFactory)) }
+    let(:registry) { described_class.new(Filterameter::FilterFactory.new(Project)) }
     let(:filter_names) { registry.filter_declarations.map(&:parameter_name) }
 
     it 'stores two declarations' do
@@ -23,14 +23,36 @@ RSpec.describe Filterameter::FilterRegistry do
       expect(registry.filter_declarations.map(&:name).uniq).to contain_exactly('date')
     end
 
-    it 'adds min filters' do
-      registry.add_filter(:date, range: :min_only)
-      expect(filter_names).to contain_exactly('date', 'date_min')
+    context 'with min-only range' do
+      before { registry.add_filter(:date, range: :min_only) }
+
+      it 'adds min filters' do
+        expect(filter_names).to contain_exactly('date', 'date_min')
+      end
+
+      it 'builds attribute filter' do
+        expect(registry.fetch('date')).to be_a Filterameter::Filters::AttributeFilter
+      end
+
+      it 'builds minimum filter' do
+        expect(registry.fetch('date_min')).to be_a Filterameter::Filters::MinimumFilter
+      end
     end
 
-    it 'adds max filters' do
-      registry.add_filter(:date, range: :max_only)
-      expect(filter_names).to contain_exactly('date', 'date_max')
+    context 'with max-only range' do
+      before { registry.add_filter(:date, range: :max_only) }
+
+      it 'adds max filters' do
+        expect(filter_names).to contain_exactly('date', 'date_max')
+      end
+
+      it 'builds attribute filter' do
+        expect(registry.fetch('date')).to be_a Filterameter::Filters::AttributeFilter
+      end
+
+      it 'builds maximum filter' do
+        expect(registry.fetch('date_max')).to be_a Filterameter::Filters::MaximumFilter
+      end
     end
 
     context 'with name specified for range filter' do

--- a/spec/requests/range_filters_spec.rb
+++ b/spec/requests/range_filters_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Range filters', type: :request do
   end
 
   context 'when range: :min_only' do
-    context 'with exact value', skip: 're-evaluating min_only feature' do
+    context 'with exact value' do
       before { get '/activities', params: { filter: { min_only_task_count: 3 } } }
 
       it 'returns the correct number of rows' do
@@ -75,7 +75,7 @@ RSpec.describe 'Range filters', type: :request do
   end
 
   context 'when range: :max_only' do
-    context 'with exact value', skip: 're-evaluating max_only feature' do
+    context 'with exact value' do
       before { get '/activities', params: { filter: { max_only_task_count: 3 } } }
 
       it 'returns the correct number of rows' do


### PR DESCRIPTION
The range options min_only and max_only were being used by the filter declaration in two ways: to identify what was declared as well as to determine what filter should be used. The result was that the wrong filter was being built (instead of an attribute filter, there were two min or max filters built).

This change splits the question into pairs of predicate methods. The new methods `min_only?` and `max_only` speak to what was declared. The new methods `minimum_range?` and `maximum_range?` speak to what filter should be used. (The original names of `minimum?` and `maximum?` were removed since they are too vague.)