### PR TITLE
Version 0.7.0: Conditional scopes, build_query_from_filters, min/max_only

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    filterameter (0.6.1)
+    filterameter (0.7.0)
       rails (>= 6.1)
 
 GEM

--- a/lib/filterameter/version.rb
+++ b/lib/filterameter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Filterameter
-  VERSION = '0.6.1'
+  VERSION = '0.7.0'
 end


### PR DESCRIPTION
- Conditional Scopes: For scopes that do not take arguments, they will be conditionally applied depending on the boolean query parameter.
- Method build_query_from_filters: New method makes it easier to build the query directly, or override parts of the process.
- Fix for min_only/max_only ranges: Fixes the main attribute filter when a range is declared as min or max only.