### PR TITLE
Version 0.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    filterameter (0.7.0)
+    filterameter (0.8.0)
       rails (>= 6.1)
 
 GEM

--- a/lib/filterameter/version.rb
+++ b/lib/filterameter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Filterameter
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end


### PR DESCRIPTION
- most filters are sortable by default
- sort only attributes / scopes can be added
- a default sort can be specified for each controller

The query parameter `sort` is nested under `filter` and can optionally specify + or - to indicate the direction:

    ?filter[sort]=-created_at
