### PR TITLE
Filter key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,24 +300,47 @@ For example, the following sorts by size descending:
 
 `/widgets?filter[sort]=-size`
 
+### Configuration
 
-#### Override the Filter Key
+There are three configuration options:
 
-To change the source of the query parameters, override the `filter_parameters` method. Here is another way to provide a default filter:
+- action_on_undeclared_parameters
+- action_on_validation_failure
+- filter_key
+
+The configuration options can be set in an initializer, an environment file, or in `application.rb`. 
+
+The options can be set directly...
+
+`Filterameter.configuration.action_on_undeclared_parameters = :log`
+
+...or the configuration can be yielded:
 
 ```ruby
-def filter_parameters
-  super.with_defaults(active: true)
+Filterameter.configure do |config|
+  config.action_on_undeclared_parameters = :log
+  config.action_on_validation_failuer = :log
+  config.filter_key = :f
 end
 ```
 
-This also provides an easy way to nest the criteria under a key other than `filter`:
+#### Action On Undeclared Parameters
 
-```ruby
-def filter_parameters
-  params.to_unsafe_h.fetch(:criteria, {})
-end
-```
+Occurs when the filter parameter contains any keys that are not defined. Valid actions are `:log`, `:raise`, and `false` (do not take action). By default, development will log, test will raise, and production will do nothing.
+
+#### Action on Validation Failure
+
+Occurs when a filter parameter fails a validation. Valid actions are `:log`, `:raise`, and `false` (do not take action). By default, development will log, test will raise, and production will do nothing.
+
+#### Filter Key
+
+By default, the filter parameters are nested under the key `:filter`. Use this setting to override the key.
+
+If the filter parameters are NOT nested, set this to false. Doing so will restrict the filter parameters to only
+those that have been declared, meaning undeclared parameters are ignored (and the action_on_undeclared_parameters
+configuration option does not come into play).
+
+
 
 
 ## Installation

--- a/lib/filterameter/configuration.rb
+++ b/lib/filterameter/configuration.rb
@@ -23,7 +23,7 @@ module Filterameter
   # By default, the filter parameters are nested under the key :filter. Use this setting to override the key.
   #
   # If the filter parameters are NOT nested, set this to false. Doing so will restrict the filter parameters to only
-  # those that have been declared, meaning undeclared parameters be ignored (and the action_on_undeclared_parameters
+  # those that have been declared, meaning undeclared parameters are ignored (and the action_on_undeclared_parameters
   # configuration option does not come into play).
   class Configuration
     attr_accessor :action_on_undeclared_parameters, :action_on_validation_failure, :filter_key

--- a/lib/filterameter/configuration.rb
+++ b/lib/filterameter/configuration.rb
@@ -6,16 +6,27 @@ module Filterameter
   # Class Configuration stores the following settings:
   # - action_on_undeclared_parameters
   # - action_on_validation_failure
+  # - filter_key
   #
   # == Action on Undeclared Parameters
+  #
   # Occurs when the filter parameter contains any keys that are not defined. Valid actions are :log, :raise, and
   # false (do not take action). By default, development will log, test will raise, and production will do nothing.
   #
   # == Action on Validation Failure
+  #
   # Occurs when a filter parameter fails a validation. Valid actions are :log, :raise, and false (do not take action).
   # By default, development will log, test will raise, and production will do nothing.
+  #
+  # == Filter Key
+  #
+  # By default, the filter parameters are nested under the key :filter. Use this setting to override the key.
+  #
+  # If the filter parameters are NOT nested, set this to false. Doing so will restrict the filter parameters to only
+  # those that have been declared, meaning undeclared parameters be ignored (and the action_on_undeclared_parameters
+  # configuration option does not come into play).
   class Configuration
-    attr_accessor :action_on_undeclared_parameters, :action_on_validation_failure
+    attr_accessor :action_on_undeclared_parameters, :action_on_validation_failure, :filter_key
 
     def initialize
       @action_on_undeclared_parameters =
@@ -27,6 +38,8 @@ module Filterameter
           else
             false
           end
+
+      @filter_key = :filter
     end
   end
 end

--- a/lib/filterameter/declarative_filters.rb
+++ b/lib/filterameter/declarative_filters.rb
@@ -29,7 +29,13 @@ module Filterameter
     end
 
     def filter_parameters
-      params.to_unsafe_h.fetch(:filter, {})
+      filter_key = Filterameter.configuration.filter_key
+
+      if filter_key
+        params.to_unsafe_h.fetch(filter_key, {})
+      else
+        params.to_unsafe_h.slice(*self.class.filter_coordinator.filter_parameter_names, :sort)
+      end
     end
 
     private

--- a/lib/filterameter/filter_coordinator.rb
+++ b/lib/filterameter/filter_coordinator.rb
@@ -19,7 +19,7 @@ module Filterameter
   class FilterCoordinator
     attr_writer :query_variable_name
 
-    delegate :add_filter, :add_sort, to: :registry
+    delegate :add_filter, :add_sort, :filter_parameter_names, to: :registry
     delegate :build_query, to: :query_builder
 
     def initialize(controller_name, controller_path)

--- a/lib/filterameter/log_subscriber.rb
+++ b/lib/filterameter/log_subscriber.rb
@@ -14,8 +14,8 @@ module Filterameter
 
     def undeclared_parameters(event)
       debug do
-        keys = event.payload[:keys]
-        "  Undeclared filter parameter#{'s' if keys.size > 1}: #{keys.map { |e| ":#{e}" }.join(', ')}"
+        key = event.payload[:key]
+        "  Undeclared filter parameter: #{key}"
       end
     end
   end

--- a/lib/filterameter/registries/filter_registry.rb
+++ b/lib/filterameter/registries/filter_registry.rb
@@ -24,6 +24,10 @@ module Filterameter
         @declarations.values
       end
 
+      def filter_parameter_names
+        @declarations.keys
+      end
+
       private
 
       # if range is enabled, then in addition to the attribute filter this also adds min and/or max filters

--- a/lib/filterameter/registries/registry.rb
+++ b/lib/filterameter/registries/registry.rb
@@ -6,7 +6,7 @@ module Filterameter
     #
     # Class Registry records declarations and allows resulting filters and sorts to be fetched from sub-registries.
     class Registry
-      delegate :filter_declarations, :ranges, to: :@filter_registry
+      delegate :filter_declarations, :filter_parameter_names, :ranges, to: :@filter_registry
 
       def initialize(model_class)
         @filter_registry = Filterameter::Registries::FilterRegistry.new(Filterameter::FilterFactory.new(model_class))

--- a/spec/filterameter/configuration_spec.rb
+++ b/spec/filterameter/configuration_spec.rb
@@ -45,4 +45,18 @@ RSpec.describe Filterameter::Configuration do
       expect(config.action_on_validation_failure).to be false
     end
   end
+
+  describe '#filter_key' do
+    it('defaults to :filter') { expect(config.filter_key).to eq :filter }
+
+    it 'can be overrriden' do
+      config.filter_key = :criteria
+      expect(config.filter_key).to eq :criteria
+    end
+
+    it 'can be set to false' do
+      config.filter_key = false
+      expect(config.filter_key).to be false
+    end
+  end
 end

--- a/spec/requests/filter_key_configuration_spec.rb
+++ b/spec/requests/filter_key_configuration_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Filter Key configuration', type: :request do
+  fixtures :activities
+
+  before { allow(Filterameter).to receive(:configuration).and_return(custom_config) }
+
+  context 'with key overriden to f' do
+    let(:custom_config) { Filterameter::Configuration.new.tap { |c| c.filter_key = :f } }
+
+    it 'applies filter' do
+      get '/activities', params: { f: { incomplete: true } }
+      count = Activity.incomplete.count
+      expect(response.parsed_body.size).to eq count
+
+      names = Activity.incomplete.pluck(:name)
+      expect(response.parsed_body.pluck('name')).to contain_exactly(*names)
+    end
+
+    it 'applies sort' do
+      get '/activities', params: { f: { sort: :project_id } }
+
+      ordered = Activity.order(:project_id).pluck(:project_id)
+      expect(response.parsed_body.pluck('project_id')).to eq ordered
+    end
+
+    it 'fails on undeclared params (default for test env)' do
+      expect { get '/activities', params: { f: { not_a_filter: true } } }
+        .to raise_error(Filterameter::Exceptions::UndeclaredParameterError)
+    end
+  end
+
+  context 'without nesting' do
+    let(:custom_config) { Filterameter::Configuration.new.tap { |c| c.filter_key = false } }
+
+    it 'applies filter' do
+      get '/activities', params: { incomplete: true }
+      count = Activity.incomplete.count
+      expect(response.parsed_body.size).to eq count
+
+      names = Activity.incomplete.pluck(:name)
+      expect(response.parsed_body.pluck('name')).to contain_exactly(*names)
+    end
+
+    it 'applies sort' do
+      get '/activities', params: { sort: :project_id }
+
+      ordered = Activity.order(:project_id).pluck(:project_id)
+      expect(response.parsed_body.pluck('project_id')).to eq ordered
+    end
+
+    it 'ignores undeclared params' do
+      get '/activities', params: { not_a_filter: true }
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
The filter key defaults to `:filter`, but can be overridden or set to false if the filter parameters are not nested.

Resolves #117 