### PR TITLE
Version 0.9.0: Configurable Filter Key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    filterameter (0.8.0)
+    filterameter (0.9.0)
       rails (>= 6.1)
 
 GEM

--- a/lib/filterameter/version.rb
+++ b/lib/filterameter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Filterameter
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end


### PR DESCRIPTION
The filter key defaults to `filter` but can be configured to any other string, as well as to indicate that the filter parameters are not nested.