### PR TITLE
Enable controller tests for declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,22 @@ If the filter parameters are NOT nested, set this to false. Doing so will restri
 those that have been declared, meaning undeclared parameters are ignored (and the action_on_undeclared_parameters
 configuration option does not come into play).
 
+### Testing Declarations
 
+The declarations can be tested for each controller, catching typos, incorrectly defined scopes, or any other issues. Method `declarations_validator` is added to each controller, and a single controller test can be added to validate all the declarations for that controller.
 
+An RSpec test might look like this:
+
+```ruby
+expect(WidgetsController.declarations_validator).to be_valid
+```
+
+In Minitest it might look like this:
+
+```ruby
+validator = WidgetsController.declarations_validator
+assert_predicate validator, :valid?, -> { validator.errors }
+```
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/lib/filterameter/declaration_errors.rb
+++ b/lib/filterameter/declaration_errors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module DeclarationErrors
+    # = Declaration Error
+    #
+    # Error DeclarationError provides a base class for errors from filter or sort declarations.
+    class DeclarationError < StandardError
+    end
+  end
+end

--- a/lib/filterameter/declaration_errors/cannot_be_inline_scope_error.rb
+++ b/lib/filterameter/declaration_errors/cannot_be_inline_scope_error.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module DeclarationErrors
+    # = CannotBeInlineScopeError
+    #
+    # Error CannotBeInlineScopeError occurs when an inline scope has been used to define a filter that takes a
+    # parameter. This is not valid for use as a Filterameter filter because an inline scope always has an arity of -1
+    # meaning the factory cannot tell if it has an argument or not. As such, all inline scopes are assumed to not have
+    # arguments and thus be conditional scopes.
+    #
+    # [The Rails guide](https://guides.rubyonrails.org/active_record_querying.html#passing-in-arguments) provides
+    # guidance suggesting scopes that take arguments be written as class methods. This takes that guidance a step
+    # further and makes it a requirement for a scope that will be used as a filter.
+    class CannotBeInlineScopeError < DeclarationError
+      def initialize(model_name, scope_name)
+        super(<<~ERROR.chomp)
+          #{model_name} scope '#{scope_name}' needs to be written as a class method, not as an inline scope. This is a
+            suggestion from the Rails guide but a requirement in order to use a scope that has an argument as a filter.
+        ERROR
+      end
+    end
+  end
+end

--- a/lib/filterameter/declaration_errors/filter_scope_argument_error.rb
+++ b/lib/filterameter/declaration_errors/filter_scope_argument_error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module DeclarationErrors
+    # = Filter Scope Argument Error
+    #
+    # Error FilterScopeArgumentError occurs when a scope used as a filter but does not have either zero or one
+    # arument. A conditional scope filter should take zero arguments; other scope filters should take one argument.
+    class FilterScopeArgumentError < DeclarationError
+      def initialize(model_name, scope_name)
+        super("#{model_name} scope '#{scope_name}' takes too many arguments. Scopes for filters can only have either " \
+              'zero (conditional scope) or one argument')
+      end
+    end
+  end
+end

--- a/lib/filterameter/declaration_errors/no_such_attribute_error.rb
+++ b/lib/filterameter/declaration_errors/no_such_attribute_error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module DeclarationErrors
+    # = No Such Attribute Error
+    #
+    # Error NoSuchAttributeError occurs when a filter or sort references an attribute that does not exist on the model.
+    # The most likely case of this is a typo. Note that if the typo was supposed to reference a scope, this error is
+    # added as attributes are assumed when no matching scopes are found.
+    class NoSuchAttributeError < DeclarationError
+      def initialize(model_name, attribute_name)
+        super("Attribute '#{attribute_name}' does not exist on #{model_name}")
+      end
+    end
+  end
+end

--- a/lib/filterameter/declaration_errors/not_a_scope_error.rb
+++ b/lib/filterameter/declaration_errors/not_a_scope_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module DeclarationErrors
+    # = Not A Scope Error
+    #
+    # Error NotAScopeError flags a class method that has been used as a filter but is not a scope. This could occur if
+    # there is a class method of the same name an attribute, in which case the class method is going to block the
+    # creation of an attribute filter. The work around (if the class method cannot be renamed) is to create a scope
+    # that provides a filter on the attribute.
+    class NotAScopeError < DeclarationError
+      def initialize(model_name, scope_name)
+        super("#{model_name} class method '#{scope_name}' is not a scope.")
+      end
+    end
+  end
+end

--- a/lib/filterameter/declaration_errors/sort_scope_requires_one_argument_error.rb
+++ b/lib/filterameter/declaration_errors/sort_scope_requires_one_argument_error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module DeclarationErrors
+    # = Sort Scope Requires One Argument Error
+    #
+    # Error SortScopeRequiresOneArgumentError occurs when a sort has been declared for a scope that does not take
+    # exactly one argument. Sort scopes must take a single argument and will receive either :asc or :desc to indicate
+    # the direction.
+    class SortScopeRequiresOneArgumentError < DeclarationError
+      def initialize(model_name, scope_name)
+        super("#{model_name} scope '#{scope_name}' must take exactly one argument to sort by.")
+      end
+    end
+  end
+end

--- a/lib/filterameter/declaration_errors/unexpected_error.rb
+++ b/lib/filterameter/declaration_errors/unexpected_error.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module DeclarationErrors
+    # = Unexpected Error
+    #
+    # Error UnexpectedError occurs when the filter or scope factory raises an exception that the validator did not
+    # expect.
+    class UnexpectedError < DeclarationError
+      def initialize(error)
+        super(<<~ERROR)
+          The previous error was unexpected. It occurred during while building a filter or sort (see below). Please
+          report this to the library so that the error can be handled and provide clearer feedback about what is wrong
+          with the declaration.
+
+          #{error.message}
+            #{error.backtrace.join("\n\t")}
+        ERROR
+      end
+    end
+  end
+end

--- a/lib/filterameter/declarations_validator.rb
+++ b/lib/filterameter/declarations_validator.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Filterameter
+  # = Declarations Validator
+  #
+  # Class DeclarationsValidtor fetches each filter and sort from the registry to validate the declaration. This class
+  # can be accessed from the controller as `declarations_validator` (via the FilterCoordinator) and be used in tests.
+  #
+  # Use the `valid?` method to test, then report errors with the `errors` attribute.
+  #
+  # A test in RSpec might look like this:
+  #
+  #   expect(WidgetsController.declarations_validator).to be_valid
+  #
+  # In Minitest it might look like this:
+  #
+  #   assert WidgetsController.declarations_validator.valid?, WidgetsController.declarations_validator.errors
+  class DeclarationsValidator
+    include Filterameter::Errors
+
+    def initialize(controller_name, model, registry)
+      @controller_name = controller_name
+      @model = model
+      @registry = registry
+    end
+
+    def inspect
+      "filter declarations on #{@controller_name.titleize}Controller"
+    end
+
+    private
+
+    def validate(_)
+      @errors.push(*validation_errors_for('filter', fetch_filters))
+      @errors.push(*validation_errors_for('sort', fetch_sorts))
+    end
+
+    def fetch_filters
+      @registry.filter_parameter_names.index_with { |name| fetch_filter(name) }
+    end
+
+    def fetch_filter(name)
+      @registry.fetch_filter(name)
+    rescue StandardError => e
+      FactoryErrors.new("Filter factory failed to build #{name}: #{e.message}")
+    end
+
+    def fetch_sorts
+      (@registry.sort_parameter_names - @registry.filter_parameter_names).index_with { |name| fetch_sort(name) }
+    end
+
+    def fetch_sort(name)
+      @registry.fetch_sort(name)
+    rescue StandardError => e
+      FactoryErrors.new("Sort factory failed to build #{name}: #{e.message}")
+    end
+
+    def validation_errors_for(type, items)
+      items.select { |_name, item| item.respond_to? :valid? }
+           .reject { |_name, item| item.valid?(@model) }
+           .map { |name, item| error_message(type, name, item.errors) }
+    end
+
+    def error_message(type, name, errors)
+      "\nInvalid #{type} for '#{name}':\n  #{errors.join("\n  ")}"
+    end
+
+    # = Factory Errors
+    #
+    # Class FactoryErrors is swapped in if the fetch from a factory fails. It is always invalid and provides the reason.
+    class FactoryErrors
+      def initialize(message)
+        @message = message
+      end
+
+      def valid?(_)
+        false
+      end
+
+      def errors
+        [@message]
+      end
+    end
+  end
+end

--- a/lib/filterameter/declarations_validator.rb
+++ b/lib/filterameter/declarations_validator.rb
@@ -28,6 +28,10 @@ module Filterameter
       "filter declarations on #{@controller_name.titleize}Controller"
     end
 
+    def errors
+      @errors&.join("\n")
+    end
+
     private
 
     def validate(_)

--- a/lib/filterameter/declarative_filters.rb
+++ b/lib/filterameter/declarative_filters.rb
@@ -10,6 +10,8 @@ module Filterameter
     include Filterameter::Sortable
 
     class_methods do
+      delegate :declarations_validator, to: :filter_coordinator
+
       def filter_model(model_class, query_var_name = nil)
         filter_coordinator.model_class = model_class
         filter_query_var_name(query_var_name) if query_var_name.present?

--- a/lib/filterameter/errors.rb
+++ b/lib/filterameter/errors.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Filterameter
+  # = Errors
+  #
+  # Module Errors provides `valid?` and `errors` to implementing classes. If the `valid?` method is not overridden,
+  # then it returns true.
+  #
+  # To provide validations rules, override `validate`. If any fail, populate the errors attribute with the
+  # reason for the failures.
+  module Errors
+    attr_reader :errors
+
+    def valid?(model = nil)
+      @errors = []
+      validate(model)
+      @errors.empty?
+    end
+
+    private
+
+    def validate(_model); end
+  end
+end

--- a/lib/filterameter/filter_coordinator.rb
+++ b/lib/filterameter/filter_coordinator.rb
@@ -45,6 +45,10 @@ module Filterameter
       end
     end
 
+    def declarations_validator
+      Filterameter::DeclarationsValidator.new(@controller_name, model_class, registry)
+    end
+
     private
 
     def model_class

--- a/lib/filterameter/filter_factory.rb
+++ b/lib/filterameter/filter_factory.rb
@@ -52,7 +52,7 @@ module Filterameter
       elsif number_of_arguments == 1
         Filterameter::Filters::ScopeFilter.new(declaration.name)
       else
-        raise ArgumentError, 'Scopes for filters can only have either zero (conditional scopes) or one argument'
+        raise Filterameter::DeclarationErrors::FilterScopeArgumentError.new(model.name, declaration.name)
       end
     end
   end

--- a/lib/filterameter/filter_factory.rb
+++ b/lib/filterameter/filter_factory.rb
@@ -46,10 +46,10 @@ module Filterameter
     # Inline scopes return an arity of -1 regardless of arguments, so those will always be assumed to be
     # conditional scopes. To have a filter that passes a value to a scope, it must be a class method.
     def build_scope_filter(model, declaration)
-      if model.method(declaration.name).arity == 1
-        Filterameter::Filters::ScopeFilter.new(declaration.name)
-      else
+      if model.method(declaration.name).arity == -1
         Filterameter::Filters::ConditionalScopeFilter.new(declaration.name)
+      else
+        Filterameter::Filters::ScopeFilter.new(declaration.name)
       end
     end
   end

--- a/lib/filterameter/filter_factory.rb
+++ b/lib/filterameter/filter_factory.rb
@@ -46,10 +46,13 @@ module Filterameter
     # Inline scopes return an arity of -1 regardless of arguments, so those will always be assumed to be
     # conditional scopes. To have a filter that passes a value to a scope, it must be a class method.
     def build_scope_filter(model, declaration)
-      if model.method(declaration.name).arity == -1
+      number_of_arguments = model.method(declaration.name).arity
+      if number_of_arguments < 1
         Filterameter::Filters::ConditionalScopeFilter.new(declaration.name)
-      else
+      elsif number_of_arguments == 1
         Filterameter::Filters::ScopeFilter.new(declaration.name)
+      else
+        raise ArgumentError, 'Scopes for filters can only have either zero (conditional scopes) or one argument'
       end
     end
   end

--- a/lib/filterameter/filters/arel_filter.rb
+++ b/lib/filterameter/filters/arel_filter.rb
@@ -6,7 +6,11 @@ module Filterameter
     #
     # Class ArelFilter is a base class for arel queries. It does not implement <tt>apply</tt>.
     class ArelFilter
+      include Filterameter::Errors
+      include Filterameter::Filters::AttributeValidator
+
       def initialize(model, attribute_name)
+        @attribute_name = attribute_name
         @arel_attribute = model.arel_table[attribute_name]
       end
     end

--- a/lib/filterameter/filters/attribute_filter.rb
+++ b/lib/filterameter/filters/attribute_filter.rb
@@ -6,12 +6,22 @@ module Filterameter
     #
     # Class AttributeFilter leverages ActiveRecord's where query method to add criteria for an attribute.
     class AttributeFilter
+      include Filterameter::Errors
+
       def initialize(attribute_name)
         @attribute_name = attribute_name
       end
 
       def apply(query, value)
         query.where(@attribute_name => value)
+      end
+
+      private
+
+      def validate(model)
+        return if model.attribute_method? @attribute_name
+
+        @errors << "Attribute '#{@attribute_name}' does not exist on #{model.name}"
       end
     end
   end

--- a/lib/filterameter/filters/attribute_filter.rb
+++ b/lib/filterameter/filters/attribute_filter.rb
@@ -7,6 +7,7 @@ module Filterameter
     # Class AttributeFilter leverages ActiveRecord's where query method to add criteria for an attribute.
     class AttributeFilter
       include Filterameter::Errors
+      include AttributeValidator
 
       def initialize(attribute_name)
         @attribute_name = attribute_name
@@ -14,14 +15,6 @@ module Filterameter
 
       def apply(query, value)
         query.where(@attribute_name => value)
-      end
-
-      private
-
-      def validate(model)
-        return if model.attribute_method? @attribute_name
-
-        @errors << "Attribute '#{@attribute_name}' does not exist on #{model.name}"
       end
     end
   end

--- a/lib/filterameter/filters/attribute_validator.rb
+++ b/lib/filterameter/filters/attribute_validator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module Filters
+    # = Attribute Validator
+    #
+    # Module AttributeValidator validates that the attribute exists on the model.
+    module AttributeValidator
+      private
+
+      def validate(model)
+        return if model.attribute_method? @attribute_name
+
+        @errors << "Attribute '#{@attribute_name}' does not exist on #{model.name}"
+      end
+    end
+  end
+end

--- a/lib/filterameter/filters/attribute_validator.rb
+++ b/lib/filterameter/filters/attribute_validator.rb
@@ -11,7 +11,7 @@ module Filterameter
       def validate(model)
         return if model.attribute_method? @attribute_name
 
-        @errors << "Attribute '#{@attribute_name}' does not exist on #{model.name}"
+        @errors << Filterameter::DeclarationErrors::NoSuchAttributeError.new(model, @attribute_name)
       end
     end
   end

--- a/lib/filterameter/filters/conditional_scope_filter.rb
+++ b/lib/filterameter/filters/conditional_scope_filter.rb
@@ -23,13 +23,13 @@ module Filterameter
       def validate(model)
         validate_is_a_scope(model)
       rescue ArgumentError
-        @errors << "#{model.name} scope '#{@scope_name}' needs to be written as a class method, not as an inline scope"
+        @errors << Filterameter::DeclarationErrors::CannotBeInlineScopeError.new(model.name, @scope_name)
       end
 
       def validate_is_a_scope(model)
         return if model.public_send(@scope_name).is_a? ActiveRecord::Relation
 
-        @errors << "#{model.name} class method '#{@scope_name}' is not a scope"
+        @errors << Filterameter::DeclarationErrors::NotAScopeError.new(model.name, @scope_name)
       end
     end
   end

--- a/lib/filterameter/filters/conditional_scope_filter.rb
+++ b/lib/filterameter/filters/conditional_scope_filter.rb
@@ -6,6 +6,8 @@ module Filterameter
     #
     # Class ConditionalScopeFilter applies the scope if the parameter is not false.
     class ConditionalScopeFilter
+      include Filterameter::Errors
+
       def initialize(scope_name)
         @scope_name = scope_name
       end
@@ -14,6 +16,20 @@ module Filterameter
         return query unless ActiveModel::Type::Boolean.new.cast(value)
 
         query.public_send(@scope_name)
+      end
+
+      private
+
+      def validate(model)
+        validate_is_a_scope(model)
+      rescue ArgumentError
+        @errors << "#{model.name} scope '#{@scope_name}' needs to be written as a class method, not as an inline scope"
+      end
+
+      def validate_is_a_scope(model)
+        return if model.public_send(@scope_name).is_a? ActiveRecord::Relation
+
+        @errors << "#{model.name} class method '#{@scope_name}' is not a scope"
       end
     end
   end

--- a/lib/filterameter/filters/matches_filter.rb
+++ b/lib/filterameter/filters/matches_filter.rb
@@ -6,6 +6,9 @@ module Filterameter
     #
     # Class MatchesFilter uses arel's `matches` to generate a LIKE query.
     class MatchesFilter
+      include Filterameter::Errors
+      include Filterameter::Filters::AttributeValidator
+
       def initialize(attribute_name, options)
         @attribute_name = attribute_name
         @prefix = options.match_anywhere? ? '%' : nil

--- a/lib/filterameter/filters/nested_filter.rb
+++ b/lib/filterameter/filters/nested_filter.rb
@@ -6,6 +6,8 @@ module Filterameter
     #
     # Class NestedFilter joins the nested table(s) then merges the filter to the association's model.
     class NestedFilter
+      include Filterameter::Errors
+
       def initialize(association_names, association_model, attribute_filter)
         @joins_values = Filterameter::Helpers::JoinsValuesBuilder.build(association_names)
         @association_model = association_model
@@ -15,6 +17,19 @@ module Filterameter
       def apply(query, value)
         query.joins(@joins_values)
              .merge(@attribute_filter.apply(@association_model.all, value))
+      end
+
+      private
+
+      def validate(model)
+        @errors.push(*@attribute_filter.errors) unless @attribute_filter.valid?(@association_model)
+        validate_associations(model)
+      end
+
+      def validate_associations(model)
+        model.joins(@joins_values).to_sql
+      rescue ActiveRecord::ConfigurationError => e
+        @errors << e.message
       end
     end
   end

--- a/lib/filterameter/filters/scope_filter.rb
+++ b/lib/filterameter/filters/scope_filter.rb
@@ -6,12 +6,26 @@ module Filterameter
     #
     # Class ScopeFilter applies the named scope passing in the parameter value.
     class ScopeFilter
+      include Filterameter::Errors
+
       def initialize(scope_name)
         @scope_name = scope_name
       end
 
       def apply(query, value)
         query.public_send(@scope_name, value)
+      end
+
+      private
+
+      def validate(model)
+        validate_is_a_scope(model)
+      end
+
+      def validate_is_a_scope(model)
+        return if model.public_send(@scope_name, '42').is_a? ActiveRecord::Relation
+
+        @errors << "#{model.name} class method '#{@scope_name}' is not a scope"
       end
     end
   end

--- a/lib/filterameter/filters/scope_filter.rb
+++ b/lib/filterameter/filters/scope_filter.rb
@@ -25,7 +25,7 @@ module Filterameter
       def validate_is_a_scope(model)
         return if model.public_send(@scope_name, '42').is_a? ActiveRecord::Relation
 
-        @errors << "#{model.name} class method '#{@scope_name}' is not a scope"
+        @errors << Filterameter::DeclarationErrors::NotAScopeError.new(model.name, @scope_name)
       end
     end
   end

--- a/lib/filterameter/registries/filter_registry.rb
+++ b/lib/filterameter/registries/filter_registry.rb
@@ -24,10 +24,6 @@ module Filterameter
         @declarations.values
       end
 
-      def filter_parameter_names
-        @declarations.keys
-      end
-
       private
 
       # if range is enabled, then in addition to the attribute filter this also adds min and/or max filters

--- a/lib/filterameter/registries/registry.rb
+++ b/lib/filterameter/registries/registry.rb
@@ -6,7 +6,9 @@ module Filterameter
     #
     # Class Registry records declarations and allows resulting filters and sorts to be fetched from sub-registries.
     class Registry
-      delegate :filter_declarations, :filter_parameter_names, :ranges, to: :@filter_registry
+      delegate :filter_declarations, :ranges, to: :@filter_registry
+      delegate :parameter_names, prefix: :filter, to: :@filter_registry
+      delegate :parameter_names, prefix: :sort, to: :@sort_registry
 
       def initialize(model_class)
         @filter_registry = Filterameter::Registries::FilterRegistry.new(Filterameter::FilterFactory.new(model_class))

--- a/lib/filterameter/registries/sort_registry.rb
+++ b/lib/filterameter/registries/sort_registry.rb
@@ -7,6 +7,10 @@ module Filterameter
     # Class SortRegistry is a collection of the sorts. It captures the declarations when classes are loaded,
     # then uses the injected SortFactory to build the sorts on demand as they are needed.
     class SortRegistry < SubRegistry
+      def sort_parameter_names
+        @declarations.keys
+      end
+
       private
 
       def build_declaration(name, options)

--- a/lib/filterameter/registries/sub_registry.rb
+++ b/lib/filterameter/registries/sub_registry.rb
@@ -28,6 +28,10 @@ module Filterameter
           @registry[name] = @factory.build(@declarations[name])
         end
       end
+
+      def parameter_names
+        @declarations.keys
+      end
     end
   end
 end

--- a/lib/filterameter/sort_factory.rb
+++ b/lib/filterameter/sort_factory.rb
@@ -33,7 +33,7 @@ module Filterameter
 
     def build_sort(name, declaration_is_a_scope)
       if declaration_is_a_scope
-        Filterameter::Filters::ScopeFilter.new(name)
+        Filterameter::Sorts::ScopeSort.new(name)
       else
         Filterameter::Sorts::AttributeSort.new(name)
       end

--- a/lib/filterameter/sorts/attribute_sort.rb
+++ b/lib/filterameter/sorts/attribute_sort.rb
@@ -6,6 +6,9 @@ module Filterameter
     #
     # Class AttributeSort leverages ActiveRecord's `order` query method to add sorting for an attribute.
     class AttributeSort
+      include Filterameter::Errors
+      include Filterameter::Filters::AttributeValidator
+
       def initialize(attribute_name)
         @attribute_name = attribute_name
       end

--- a/lib/filterameter/sorts/scope_sort.rb
+++ b/lib/filterameter/sorts/scope_sort.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Filterameter
+  module Sorts
+    # = Scope Sort
+    #
+    # Class ScopeSort applies the scope with the a param that is either :asc or :desc. A scope that does not take
+    # exactly one argument is not valid for sorting.
+    class ScopeSort < Filterameter::Filters::ScopeFilter
+      private
+
+      def validate(model)
+        validate_is_a_scope(model)
+      rescue ArgumentError
+        @errors << "#{model.name} scope '#{@scope_name}' must take exactly one argument to sort by"
+      end
+
+      def validate_is_a_scope(model)
+        return if model.public_send(@scope_name, :asc).is_a? ActiveRecord::Relation
+
+        @errors << "#{model.name} class method '#{@scope_name}' is not a scope"
+      end
+    end
+  end
+end

--- a/lib/filterameter/sorts/scope_sort.rb
+++ b/lib/filterameter/sorts/scope_sort.rb
@@ -12,13 +12,13 @@ module Filterameter
       def validate(model)
         validate_is_a_scope(model)
       rescue ArgumentError
-        @errors << "#{model.name} scope '#{@scope_name}' must take exactly one argument to sort by"
+        @errors << Filterameter::DeclarationErrors::SortScopeRequiresOneArgumentError.new(model.name, @scope_name)
       end
 
       def validate_is_a_scope(model)
         return if model.public_send(@scope_name, :asc).is_a? ActiveRecord::Relation
 
-        @errors << "#{model.name} class method '#{@scope_name}' is not a scope"
+        @errors << Filterameter::DeclarationErrors::NotAScopeError.new(model.name, @scope_name)
       end
     end
   end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ActivitiesController, type: :controller do
     declarations = described_class.declarations_validator
     declarations.valid?
 
-    expect(declarations.errors.join("\n")).to eq <<~ERROR.chomp
+    expect(declarations.errors).to eq <<~ERROR.chomp
 
       Invalid filter for 'inline_with_arg':
         #{Filterameter::DeclarationErrors::CannotBeInlineScopeError.new('Activity', :inline_with_arg)}

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -15,22 +15,22 @@ RSpec.describe ActivitiesController, type: :controller do
     expect(declarations.errors.join("\n")).to eq <<~ERROR.chomp
 
       Invalid filter for 'inline_with_arg':
-        Activity scope 'inline_with_arg' needs to be written as a class method, not as an inline scope
+        #{Filterameter::DeclarationErrors::CannotBeInlineScopeError.new('Activity', :inline_with_arg)}
 
       Invalid filter for 'not_a_scope':
-        Activity class method 'not_a_scope' is not a scope
+        #{Filterameter::DeclarationErrors::NotAScopeError.new('Activity', :not_a_scope)}
 
       Invalid filter for 'not_a_conditional_scope':
-        Activity class method 'not_a_conditional_scope' is not a scope
+        #{Filterameter::DeclarationErrors::NotAScopeError.new('Activity', :not_a_conditional_scope)}
 
       Invalid filter for 'scope_with_multiple_args':
-        Filter factory failed to build scope_with_multiple_args: Scopes for filters can only have either zero (conditional scopes) or one argument
+        #{Filterameter::DeclarationErrors::FilterScopeArgumentError.new('Activity', :scope_with_multiple_args)}
 
       Invalid sort for 'updated_at_typo':
-        Attribute 'updated_at_typo' does not exist on Activity
+        #{Filterameter::DeclarationErrors::NoSuchAttributeError.new('Activity', :updated_at_typo)}
 
       Invalid sort for 'sort_scope_with_no_args':
-        Activity scope 'sort_scope_with_no_args' must take exactly one argument to sort by
+        #{Filterameter::DeclarationErrors::SortScopeRequiresOneArgumentError.new('Activity', :sort_scope_with_no_args)}
     ERROR
   end
 end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivitiesController, type: :controller do
+  it 'flags invalid declarations' do
+    declarations = described_class.declarations_validator
+    expect(declarations).not_to be_valid
+  end
+
+  it 'provides clear explanations for invalid declarations' do
+    declarations = described_class.declarations_validator
+    declarations.valid?
+
+    expect(declarations.errors.join("\n")).to eq <<~ERROR.chomp
+
+      Invalid filter for 'inline_with_arg':
+        Activity scope 'inline_with_arg' needs to be written as a class method, not as an inline scope
+
+      Invalid filter for 'not_a_scope':
+        Activity class method 'not_a_scope' is not a scope
+
+      Invalid filter for 'not_a_conditional_scope':
+        Activity class method 'not_a_conditional_scope' is not a scope
+
+      Invalid filter for 'scope_with_multiple_args':
+        Filter factory failed to build scope_with_multiple_args: Scopes for filters can only have either zero (conditional scopes) or one argument
+
+      Invalid sort for 'updated_at_typo':
+        Attribute 'updated_at_typo' does not exist on Activity
+
+      Invalid sort for 'sort_scope_with_no_args':
+        Activity scope 'sort_scope_with_no_args' must take exactly one argument to sort by
+    ERROR
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProjectsController, type: :controller do
+  it 'has valid declarations' do
+    declarations = described_class.declarations_validator
+    expect(declarations).to be_valid
+  end
+end

--- a/spec/dummy/app/controllers/activities_controller.rb
+++ b/spec/dummy/app/controllers/activities_controller.rb
@@ -18,6 +18,14 @@ class ActivitiesController < ApplicationController
   sort :completed
   sort :project_id
 
+  # invalid declarations
+  filter :inline_with_arg
+  filter :not_a_scope
+  filter :not_a_conditional_scope
+  filter :scope_with_multiple_args
+  sort :updated_at_typo
+  sort :sort_scope_with_no_args
+
   default_sort project_id: :desc
 
   def index

--- a/spec/dummy/app/controllers/projects_controller.rb
+++ b/spec/dummy/app/controllers/projects_controller.rb
@@ -8,6 +8,9 @@ class ProjectsController < ApplicationController
   filter :with_incomplete_tasks, name: :incomplete, association: %i[activities tasks]
   filter :in_progress
 
+  sort :by_created_at
+  sort :by_project_id
+
   def index
     @projects = build_query_from_filters
 

--- a/spec/dummy/app/models/activity.rb
+++ b/spec/dummy/app/models/activity.rb
@@ -8,9 +8,7 @@ class Activity < ApplicationRecord
 
   scope :incomplete, -> { where(completed: false) }
 
-  # these two could be handled by attribute sorts, added here for testing purposes only
-  scope :by_active, ->(dir) { order(active: dir) }
-
+  # this could be handled by attribute sort, added here for testing purposes only
   def self.by_task_count(dir)
     order(task_count: dir)
   end

--- a/spec/dummy/app/models/activity.rb
+++ b/spec/dummy/app/models/activity.rb
@@ -7,4 +7,22 @@ class Activity < ApplicationRecord
   has_many :tasks
 
   scope :incomplete, -> { where(completed: false) }
+
+  # no visibility to the arg when inline, so filterameter assumes it is a conditional scope
+  scope :inline_with_arg, ->(arg) { where(completed: arg) }
+
+  # a class method that would get flagged as a scope by the factory, but does not return an arel
+  def self.not_a_scope(arg)
+    arg
+  end
+
+  # a class method that would get flagged as a conditional scope by the factory, but does not return an arel
+  def self.not_a_conditional_scope
+    42
+  end
+
+  # filters only support single argument scopes
+  def self.scope_with_multiple_args(completed, name)
+    where(completed:, name:)
+  end
 end

--- a/spec/dummy/app/models/activity.rb
+++ b/spec/dummy/app/models/activity.rb
@@ -8,6 +8,13 @@ class Activity < ApplicationRecord
 
   scope :incomplete, -> { where(completed: false) }
 
+  # these two could be handled by attribute sorts, added here for testing purposes only
+  scope :by_active, ->(dir) { order(active: dir) }
+
+  def self.by_task_count(dir)
+    order(task_count: dir)
+  end
+
   # no visibility to the arg when inline, so filterameter assumes it is a conditional scope
   scope :inline_with_arg, ->(arg) { where(completed: arg) }
 
@@ -24,5 +31,16 @@ class Activity < ApplicationRecord
   # filters only support single argument scopes
   def self.scope_with_multiple_args(completed, name)
     where(completed:, name:)
+  end
+
+  # sort scopes must have exactly one argement
+  scope :inline_sort_scope_with_no_args, -> { Activity.order(:created_at) }
+
+  def self.sort_scope_with_no_args
+    Activity.order(:created_at)
+  end
+
+  def self.sort_scope_with_two_args(one, two)
+    Activity.order(one, two)
   end
 end

--- a/spec/dummy/app/models/project.rb
+++ b/spec/dummy/app/models/project.rb
@@ -18,4 +18,12 @@ class Project < ApplicationRecord
   def self.by_created_at(dir)
     order(created_at: dir)
   end
+
+  # could be handled by an attribute sort, added for testing purposes only
+  scope :by_project_id, ->(dir) { order(id: dir) }
+
+  # multi-argument scope, not valid for filter
+  def self.multi_arg_scope(active, priority)
+    where(active:, priority:)
+  end
 end

--- a/spec/filterameter/declarations_validator_spec.rb
+++ b/spec/filterameter/declarations_validator_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Filterameter::DeclarationsValidator do
+  specify '#inspect' do
+    validator = described_class.new('activities', Activity, nil)
+    expect(validator.inspect).to eq 'filter declarations on ActivitiesController'
+  end
+
+  describe '#valid?' do
+    let(:validator) { described_class.new('activities', Activity, registry) }
+
+    context 'with valid filters and sorts' do
+      let(:registry) do
+        Filterameter::Registries::Registry.new(Activity).tap do |r|
+          r.add_filter(:name, {})
+          r.add_filter(:task_count, {})
+          r.add_sort(:created_at, {})
+          r.add_sort(:updated_at, {})
+        end
+      end
+
+      it 'is valid' do
+        validator = described_class.new('activities', Activity, registry)
+        expect(validator).to be_valid
+      end
+    end
+
+    let(:not_an_attribute_error) do
+      <<~ERROR.chomp
+
+        Invalid filter for 'not_an_attribute':
+          Attribute 'not_an_attribute' does not exist on Activity
+      ERROR
+    end
+
+    let(:updated_at_typo_error) do
+      <<~ERROR.chomp
+
+        Invalid sort for 'updated_at_typo':
+          Attribute 'updated_at_typo' does not exist on Activity
+      ERROR
+    end
+
+    context 'with invalid filter' do
+      let(:registry) do
+        Filterameter::Registries::Registry.new(Activity).tap do |r|
+          r.add_filter(:name, {})
+          r.add_filter(:not_an_attribute, {})
+          r.add_sort(:created_at, {})
+          r.add_sort(:updated_at, {})
+        end
+      end
+
+      it 'is not valid' do
+        expect(validator).not_to be_valid
+      end
+
+      it 'reports error' do
+        validator.valid?
+        expect(validator.errors).to contain_exactly not_an_attribute_error
+      end
+    end
+
+    context 'with invalid sort' do
+      let(:registry) do
+        Filterameter::Registries::Registry.new(Activity).tap do |r|
+          r.add_filter(:name, {})
+          r.add_sort(:created_at, {})
+          r.add_sort(:updated_at_typo, {})
+        end
+      end
+
+      let(:validator) { described_class.new('activities', Activity, registry) }
+
+      it 'is not valid' do
+        expect(validator).not_to be_valid
+      end
+
+      it 'reports error' do
+        validator.valid?
+        expect(validator.errors).to contain_exactly updated_at_typo_error
+      end
+    end
+
+    context 'with invalid filter and invalid sort' do
+      let(:registry) do
+        Filterameter::Registries::Registry.new(Activity).tap do |r|
+          r.add_filter(:name, {})
+          r.add_filter(:not_an_attribute, {})
+          r.add_sort(:created_at, {})
+          r.add_sort(:updated_at_typo, {})
+        end
+      end
+
+      let(:validator) { described_class.new('activities', Activity, registry) }
+
+      it 'is not valid' do
+        expect(validator).not_to be_valid
+      end
+
+      it 'reports error' do
+        validator.valid?
+        expect(validator.errors).to contain_exactly(not_an_attribute_error, updated_at_typo_error)
+      end
+    end
+
+    context 'with inline scope that should be class method' do
+      let(:registry) do
+        Filterameter::Registries::Registry.new(Activity).tap do |r|
+          r.add_filter(:inline_with_arg, {})
+        end
+      end
+
+      it 'is not valid' do
+        expect(validator).not_to be_valid
+      end
+
+      it 'reports error' do
+        validator.valid?
+        expect(validator.errors).to contain_exactly <<~ERROR.chomp
+
+          Invalid filter for 'inline_with_arg':
+            Activity scope 'inline_with_arg' needs to be written as a class method, not as an inline scope
+        ERROR
+      end
+    end
+  end
+end

--- a/spec/filterameter/declarations_validator_spec.rb
+++ b/spec/filterameter/declarations_validator_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Filterameter::DeclarationsValidator do
 
       it 'reports error' do
         validator.valid?
-        expect(validator.errors).to contain_exactly not_an_attribute_error
+        expect(validator.errors).to eq not_an_attribute_error
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Filterameter::DeclarationsValidator do
 
       it 'reports error' do
         validator.valid?
-        expect(validator.errors).to contain_exactly updated_at_typo_error
+        expect(validator.errors).to eq updated_at_typo_error
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe Filterameter::DeclarationsValidator do
 
       it 'reports error' do
         validator.valid?
-        expect(validator.errors).to contain_exactly(not_an_attribute_error, updated_at_typo_error)
+        expect(validator.errors).to eq [not_an_attribute_error, updated_at_typo_error].join("\n")
       end
     end
 
@@ -119,7 +119,7 @@ RSpec.describe Filterameter::DeclarationsValidator do
 
       it 'reports error' do
         validator.valid?
-        expect(validator.errors).to contain_exactly <<~ERROR.chomp
+        expect(validator.errors).to eq <<~ERROR.chomp
 
           Invalid filter for 'inline_with_arg':
             #{Filterameter::DeclarationErrors::CannotBeInlineScopeError.new('Activity', :inline_with_arg)}
@@ -145,7 +145,7 @@ RSpec.describe Filterameter::DeclarationsValidator do
 
         it 'reports error' do
           validator.valid?
-          expect(validator.errors).to contain_exactly <<~ERROR.chomp
+          expect(validator.errors).to eq <<~ERROR.chomp
 
             Invalid filter for 'name':
               #{described_class::FactoryErrors.new(error)}
@@ -162,7 +162,7 @@ RSpec.describe Filterameter::DeclarationsValidator do
 
         it 'reports error' do
           validator.valid?
-          expect(validator.errors).to contain_exactly <<~ERROR.chomp
+          expect(validator.errors).to eq <<~ERROR.chomp
 
             Invalid filter for 'name':
               #{Filterameter::DeclarationErrors::UnexpectedError.new(error)}

--- a/spec/filterameter/errors_spec.rb
+++ b/spec/filterameter/errors_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Filterameter::Errors do
+  context 'without a validate implementation' do
+    let(:filter) do
+      Class.new do
+        include Filterameter::Errors
+      end.new
+    end
+
+    it 'is valid' do
+      expect(filter).to be_valid
+    end
+  end
+
+  context 'with a validate implementation' do
+    let(:filter) do
+      Class.new do
+        include Filterameter::Errors
+
+        private
+
+        def validate(dummy_error)
+          return if dummy_error.nil?
+
+          @errors << dummy_error
+        end
+      end.new
+    end
+
+    it 'is valid with no error' do
+      expect(filter).to be_valid
+    end
+
+    context 'with an error' do
+      it 'is not valid' do
+        expect(filter.valid?('error message')).to be false
+      end
+
+      it 'includes error message' do
+        filter.valid?('error message')
+        expect(filter.errors).to contain_exactly 'error message'
+      end
+    end
+  end
+end

--- a/spec/filterameter/filter_factory_spec.rb
+++ b/spec/filterameter/filter_factory_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe Filterameter::FilterFactory do
 
   context 'with a multi-argument scope declaration' do
     let(:declaration) { Filterameter::FilterDeclaration.new(:multi_arg_scope, {}) }
-    it('raises ArgumentError') { expect { filter }.to raise_error(ArgumentError) }
+    it('raises FilterScopeArgumentError') do
+      expect { filter }.to raise_error(Filterameter::DeclarationErrors::FilterScopeArgumentError)
+    end
   end
 
   context 'with partial declaration' do

--- a/spec/filterameter/filter_factory_spec.rb
+++ b/spec/filterameter/filter_factory_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Filterameter::FilterFactory do
     it('is a ConditionalScopeFilter') { expect(filter).to be_a Filterameter::Filters::ConditionalScopeFilter }
   end
 
+  context 'with a multi-argument scope declaration' do
+    let(:declaration) { Filterameter::FilterDeclaration.new(:multi_arg_scope, {}) }
+    it('raises ArgumentError') { expect { filter }.to raise_error(ArgumentError) }
+  end
+
   context 'with partial declaration' do
     let(:declaration) { Filterameter::FilterDeclaration.new(:name, { partial: true }) }
     it('is a MatchesFilter') { expect(filter).to be_a Filterameter::Filters::MatchesFilter }

--- a/spec/filterameter/filters/attribute_filter_spec.rb
+++ b/spec/filterameter/filters/attribute_filter_spec.rb
@@ -3,11 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Filterameter::Filters::AttributeFilter do
-  let(:filter) { described_class.new(:color) }
-  let(:query) { class_spy('ActiveRecord::Base') }
-
   it 'applies filter to query' do
+    filter = described_class.new(:color)
+    query = class_spy('ActiveRecord::Base')
+
     filter.apply(query, 'blue')
     expect(query).to have_received(:where).with(color: 'blue')
+  end
+
+  it 'is valid with valid attribute' do
+    filter = described_class.new(:name)
+    expect(filter.valid?(Activity)).to be true
+  end
+
+  context 'with invalid attribute' do
+    let(:filter) { described_class.new(:not_a_thing) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Activity)).to be false
+    end
+
+    it 'reports errors' do
+      filter.valid?(Activity)
+      expect(filter.errors).to contain_exactly "Attribute 'not_a_thing' does not exist on Activity"
+    end
   end
 end

--- a/spec/filterameter/filters/attribute_filter_spec.rb
+++ b/spec/filterameter/filters/attribute_filter_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Filterameter::Filters::AttributeFilter do
 
     it 'reports errors' do
       filter.valid?(Activity)
-      expect(filter.errors).to contain_exactly "Attribute 'not_a_thing' does not exist on Activity"
+      expect(filter.errors)
+        .to contain_exactly Filterameter::DeclarationErrors::NoSuchAttributeError.new('Activity', :not_a_thing)
     end
   end
 end

--- a/spec/filterameter/filters/conditional_scope_filter_spec.rb
+++ b/spec/filterameter/filters/conditional_scope_filter_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe Filterameter::Filters::ConditionalScopeFilter do
 
     it 'reports error' do
       filter.valid?(Activity)
-      expect(filter.errors).to contain_exactly "Activity class method 'not_a_conditional_scope' is not a scope"
+      expect(filter.errors).to contain_exactly(
+        Filterameter::DeclarationErrors::NotAScopeError.new('Activity', :not_a_conditional_scope)
+      )
     end
   end
 
@@ -47,7 +49,7 @@ RSpec.describe Filterameter::Filters::ConditionalScopeFilter do
     it 'reports error' do
       filter.valid?(Activity)
       expect(filter.errors).to contain_exactly(
-        "Activity scope 'inline_with_arg' needs to be written as a class method, not as an inline scope"
+        Filterameter::DeclarationErrors::CannotBeInlineScopeError.new('Activity', :inline_with_arg)
       )
     end
   end

--- a/spec/filterameter/filters/conditional_scope_filter_spec.rb
+++ b/spec/filterameter/filters/conditional_scope_filter_spec.rb
@@ -15,4 +15,40 @@ RSpec.describe Filterameter::Filters::ConditionalScopeFilter do
     filter.apply(query, false)
     expect(query).not_to have_received('the_scope')
   end
+
+  context 'with valid conditional scope' do
+    let(:filter) { described_class.new(:incomplete) }
+
+    it 'is valid' do
+      expect(filter.valid?(Activity)).to be true
+    end
+  end
+
+  context 'with a class method that is not a scope' do
+    let(:filter) { described_class.new(:not_a_conditional_scope) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Activity)).to be false
+    end
+
+    it 'reports error' do
+      filter.valid?(Activity)
+      expect(filter.errors).to contain_exactly "Activity class method 'not_a_conditional_scope' is not a scope"
+    end
+  end
+
+  context 'with inline scope that takes an argument' do
+    let(:filter) { described_class.new(:inline_with_arg) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Activity)).to be false
+    end
+
+    it 'reports error' do
+      filter.valid?(Activity)
+      expect(filter.errors).to contain_exactly(
+        "Activity scope 'inline_with_arg' needs to be written as a class method, not as an inline scope"
+      )
+    end
+  end
 end

--- a/spec/filterameter/filters/matches_filter_spec.rb
+++ b/spec/filterameter/filters/matches_filter_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Filterameter::Filters::MatchesFilter do
+  let(:filter) { described_class.new(:name, options) }
+  let(:query) { filter.apply(Activity.all, 'prepare') }
+  let(:options) { Filterameter::Options::PartialOptions.new(true) }
+
+  context 'with partial: true' do
+    it 'valid sql' do
+      expect { query.explain }.not_to raise_exception
+    end
+
+    it 'applies criteria' do
+      expect(query.to_sql).to match(/name.*like.*%prepare%/i)
+    end
+
+    it 'is valid' do
+      expect(filter.valid?(Activity)).to be true
+    end
+  end
+
+  context 'with from start' do
+    let(:options) { Filterameter::Options::PartialOptions.new(:from_start) }
+
+    it 'valid sql' do
+      expect { query.explain }.not_to raise_exception
+    end
+
+    it 'applies criteria' do
+      expect(query.to_sql).to match(/name.*like.*prepare%/i)
+      expect(query.to_sql).not_to match(/name.*like.*%prepare%/i)
+    end
+
+    it 'is valid' do
+      expect(filter.valid?(Activity)).to be true
+    end
+  end
+
+  context 'with dynamic' do
+    let(:options) { Filterameter::Options::PartialOptions.new(:dynamic) }
+
+    it 'valid sql' do
+      expect { query.explain }.not_to raise_exception
+    end
+
+    it 'applies criteria' do
+      expect(query.to_sql).to match(/name.*like.*prepare/i)
+      expect(query.to_sql).not_to match(/name.*like.*prepare%/i)
+      expect(query.to_sql).not_to match(/name.*like.*%prepare%/i)
+    end
+
+    it 'is valid' do
+      expect(filter.valid?(Activity)).to be true
+    end
+  end
+
+  context 'with typo on attribute name' do
+    let(:filter) { described_class.new(:namez, options) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Activity)).to be false
+    end
+  end
+end

--- a/spec/filterameter/filters/maximum_filter_spec.rb
+++ b/spec/filterameter/filters/maximum_filter_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe Filterameter::Filters::MaximumFilter do
   it 'applies criteria' do
     expect(query.to_sql).to include '"activities"."task_count" <= 42'
   end
+
+  it 'is valid' do
+    expect(filter.valid?(Activity)).to be true
+  end
+
+  context 'with typo on attribute name' do
+    let(:filter) { described_class.new(Activity, :namez) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Activity)).to be false
+    end
+  end
 end

--- a/spec/filterameter/filters/minimum_filter_spec.rb
+++ b/spec/filterameter/filters/minimum_filter_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe Filterameter::Filters::MinimumFilter do
   it 'applies criteria' do
     expect(query.to_sql).to include '"activities"."task_count" >= 42'
   end
+
+  it 'is valid' do
+    expect(filter.valid?(Activity)).to be true
+  end
+
+  context 'with typo on attribute name' do
+    let(:filter) { described_class.new(Activity, :namez) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Activity)).to be false
+    end
+  end
 end

--- a/spec/filterameter/filters/nested_collection_filter_spec.rb
+++ b/spec/filterameter/filters/nested_collection_filter_spec.rb
@@ -16,5 +16,9 @@ RSpec.describe Filterameter::Filters::NestedCollectionFilter do
     it 'applies nested filter' do
       expect(result.where_values_hash('activities')).to match('name' => 'The Activity Name')
     end
+
+    it 'is valid' do
+      expect(filter.valid?(Project)).to be true
+    end
   end
 end

--- a/spec/filterameter/filters/nested_filter_spec.rb
+++ b/spec/filterameter/filters/nested_filter_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Filterameter::Filters::NestedFilter do
     expect(query.where_values_hash('activities')).to match('name' => 'The Activity Name')
   end
 
+  it 'is valid' do
+    expect(filter.valid?(Task)).to be true
+  end
+
   describe 'multi-level associations' do
     context 'with attribute filter' do
       let(:filter) do
@@ -28,11 +32,16 @@ RSpec.describe Filterameter::Filters::NestedFilter do
       it 'generates valid sql' do
         expect { query.explain }.not_to raise_exception
       end
+
+      it 'is valid' do
+        expect(filter.valid?(Task)).to be true
+      end
     end
 
     context 'with scope filter' do
       let(:filter) do
-        described_class.new(%i[activities tasks], Task, Filterameter::Filters::ConditionalScopeFilter.new(:incomplete))
+        described_class.new(%i[activities tasks], Task,
+                            Filterameter::Filters::ConditionalScopeFilter.new(:incomplete))
       end
       let(:query) { filter.apply(Project.all, true) }
 
@@ -43,6 +52,26 @@ RSpec.describe Filterameter::Filters::NestedFilter do
       it 'generates valid sql' do
         expect { query.explain }.not_to raise_exception
       end
+
+      it 'is valid' do
+        expect(filter.valid?(Project)).to be true
+      end
+    end
+  end
+
+  context 'with typo on association name' do
+    let(:filter) { described_class.new(%i[activity], Activity, Filterameter::Filters::AttributeFilter.new(:name)) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Project)).to be false
+    end
+  end
+
+  context 'with typo on attribute name' do
+    let(:filter) { described_class.new(%i[activities], Activity, Filterameter::Filters::AttributeFilter.new(:namez)) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Project)).to be false
     end
   end
 end

--- a/spec/filterameter/filters/scope_filter_spec.rb
+++ b/spec/filterameter/filters/scope_filter_spec.rb
@@ -10,4 +10,25 @@ RSpec.describe Filterameter::Filters::ScopeFilter do
     filter.apply(query, 20)
     expect(query).to have_received(:the_scope).with(20)
   end
+
+  context 'with valid scope' do
+    let(:filter) { described_class.new(:in_progress) }
+
+    it 'is valid' do
+      expect(filter.valid?(Project)).to be true
+    end
+  end
+
+  context 'with a class method that is not a scope' do
+    let(:filter) { described_class.new(:not_a_scope) }
+
+    it 'is not valid' do
+      expect(filter.valid?(Activity)).to be false
+    end
+
+    it 'reports error' do
+      filter.valid?(Activity)
+      expect(filter.errors).to contain_exactly "Activity class method 'not_a_scope' is not a scope"
+    end
+  end
 end

--- a/spec/filterameter/filters/scope_filter_spec.rb
+++ b/spec/filterameter/filters/scope_filter_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe Filterameter::Filters::ScopeFilter do
 
     it 'reports error' do
       filter.valid?(Activity)
-      expect(filter.errors).to contain_exactly "Activity class method 'not_a_scope' is not a scope"
+      expect(filter.errors).to contain_exactly(
+        Filterameter::DeclarationErrors::NotAScopeError.new('Activity', :not_a_scope)
+      )
     end
   end
 end

--- a/spec/filterameter/sorts/attribute_sort_spec.rb
+++ b/spec/filterameter/sorts/attribute_sort_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Filterameter::Sorts::AttributeSort do
 
     it 'reports errors' do
       sort.valid?(Activity)
-      expect(sort.errors).to contain_exactly "Attribute 'not_a_thing' does not exist on Activity"
+      expect(sort.errors)
+        .to contain_exactly Filterameter::DeclarationErrors::NoSuchAttributeError.new(Activity, :not_a_thing)
     end
   end
 end

--- a/spec/filterameter/sorts/attribute_sort_spec.rb
+++ b/spec/filterameter/sorts/attribute_sort_spec.rb
@@ -3,11 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Filterameter::Sorts::AttributeSort do
-  let(:filter) { described_class.new(:color) }
+  let(:sort) { described_class.new(:color) }
   let(:query) { class_spy('ActiveRecord::Base') }
 
   it 'applies sort to query' do
-    filter.apply(query, :asc)
+    sort.apply(query, :asc)
     expect(query).to have_received(:order).with(color: :asc)
+  end
+
+  it 'is valid with valid attribute' do
+    sort = described_class.new(:name)
+    expect(sort.valid?(Activity)).to be true
+  end
+
+  context 'with invalid attribute' do
+    let(:sort) { described_class.new(:not_a_thing) }
+
+    it 'is not valid' do
+      expect(sort.valid?(Activity)).to be false
+    end
+
+    it 'reports errors' do
+      sort.valid?(Activity)
+      expect(sort.errors).to contain_exactly "Attribute 'not_a_thing' does not exist on Activity"
+    end
   end
 end

--- a/spec/filterameter/sorts/scope_sort_spec.rb
+++ b/spec/filterameter/sorts/scope_sort_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe Filterameter::Sorts::ScopeSort do
 
     it 'reports error' do
       sort.valid?(Activity)
-      expect(sort.errors).to contain_exactly "Activity class method 'not_a_scope' is not a scope"
+      expect(sort.errors).to contain_exactly(
+        Filterameter::DeclarationErrors::NotAScopeError.new('Activity', :not_a_scope)
+      )
     end
   end
 
@@ -38,8 +40,10 @@ RSpec.describe Filterameter::Sorts::ScopeSort do
 
     it 'reports errors' do
       sort.valid?(Activity)
-      expect(sort.errors)
-        .to contain_exactly "Activity scope 'inline_sort_scope_with_no_args' must take exactly one argument to sort by"
+      expect(sort.errors).to contain_exactly(
+        Filterameter::DeclarationErrors::SortScopeRequiresOneArgumentError.new(Activity,
+                                                                               :inline_sort_scope_with_no_args)
+      )
     end
   end
 
@@ -52,8 +56,9 @@ RSpec.describe Filterameter::Sorts::ScopeSort do
 
     it 'reports errors' do
       sort.valid?(Activity)
-      expect(sort.errors)
-        .to contain_exactly "Activity scope 'sort_scope_with_no_args' must take exactly one argument to sort by"
+      expect(sort.errors).to contain_exactly(
+        Filterameter::DeclarationErrors::SortScopeRequiresOneArgumentError.new(Activity, :sort_scope_with_no_args)
+      )
     end
   end
 
@@ -66,8 +71,9 @@ RSpec.describe Filterameter::Sorts::ScopeSort do
 
     it 'reports errors' do
       sort.valid?(Activity)
-      expect(sort.errors)
-        .to contain_exactly "Activity scope 'sort_scope_with_two_args' must take exactly one argument to sort by"
+      expect(sort.errors).to contain_exactly(
+        Filterameter::DeclarationErrors::SortScopeRequiresOneArgumentError.new(Activity, :sort_scope_with_two_args)
+      )
     end
   end
 end

--- a/spec/filterameter/sorts/scope_sort_spec.rb
+++ b/spec/filterameter/sorts/scope_sort_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Filterameter::Sorts::ScopeSort do
+  let(:sort) { described_class.new(:by_task_count) }
+  let(:query) { class_spy('Activity') }
+
+  it 'applies sort to query' do
+    sort.apply(query, :asc)
+    expect(query).to have_received(:by_task_count).with(:asc)
+  end
+
+  it 'is valid with valid scope' do
+    sort = described_class.new(:by_task_count)
+    expect(sort.valid?(Activity)).to be true
+  end
+
+  context 'with a scope that is not a sort' do
+    let(:sort) { described_class.new(:not_a_scope) }
+
+    it 'is not valid' do
+      expect(sort.valid?(Activity)).to be false
+    end
+
+    it 'reports error' do
+      sort.valid?(Activity)
+      expect(sort.errors).to contain_exactly "Activity class method 'not_a_scope' is not a scope"
+    end
+  end
+
+  context 'with inline sort with no arguments' do
+    let(:sort) { described_class.new(:inline_sort_scope_with_no_args) }
+
+    it 'is not valid' do
+      expect(sort.valid?(Activity)).to be false
+    end
+
+    it 'reports errors' do
+      sort.valid?(Activity)
+      expect(sort.errors)
+        .to contain_exactly "Activity scope 'inline_sort_scope_with_no_args' must take exactly one argument to sort by"
+    end
+  end
+
+  context 'with class method with no aguments' do
+    let(:sort) { described_class.new(:sort_scope_with_no_args) }
+
+    it 'is not valid' do
+      expect(sort.valid?(Activity)).to be false
+    end
+
+    it 'reports errors' do
+      sort.valid?(Activity)
+      expect(sort.errors)
+        .to contain_exactly "Activity scope 'sort_scope_with_no_args' must take exactly one argument to sort by"
+    end
+  end
+
+  context 'with class method with two arguments' do
+    let(:sort) { described_class.new(:sort_scope_with_two_args) }
+
+    it 'is not valid' do
+      expect(sort.valid?(Activity)).to be false
+    end
+
+    it 'reports errors' do
+      sort.valid?(Activity)
+      expect(sort.errors)
+        .to contain_exactly "Activity scope 'sort_scope_with_two_args' must take exactly one argument to sort by"
+    end
+  end
+end

--- a/spec/requests/scope_sorts_spec.rb
+++ b/spec/requests/scope_sorts_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Scope sorts', type: :request do
+  fixtures :projects
+
+  context 'with class method scope' do
+    before { get '/projects', params: { filter: { sort: :by_created_at } } }
+
+    it 'returns successfully' do
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  context 'with inline scope' do
+    before { get '/projects', params: { filter: { sort: 'by_project_id' } } }
+
+    it 'sorts projects by id asc' do
+      ordered = response.parsed_body.pluck('id')
+      expect(ordered).to eq Project.order(id: :asc).pluck(:id)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'filterameter'
 require 'simplecov'
 
 SimpleCov.start


### PR DESCRIPTION
This adds logic so that the filters and sorts can validate themselves and report back any issues. Validations can catch the following issues:
- a typo on an attribute name
- an inline scope filter that takes an argument
- a filter scope that takes more than one argument
- a sort scope that does not take exactly one argument
- a sort scope that uses a collection association
- a class method that is used as a scope but is not a scope
