### PR TITLE
Convert comments to markdown format

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,0 +1,26 @@
+---
+encoding: UTF-8
+static_path: []
+rdoc_include: []
+page_dir:
+charset: UTF-8
+exclude:
+- "~\\z"
+- "\\.orig\\z"
+- "\\.rej\\z"
+- "\\.bak\\z"
+- "\\.gemspec\\z"
+hyperlink_all: false
+line_numbers: false
+locale_dir: locale
+locale_name:
+main_page:
+markup: markdown
+output_decoration: true
+show_hash: false
+skip_tests: true
+tab_width: 8
+template_stylesheets: []
+title:
+visibility: :protected
+webcvs:

--- a/lib/filterameter.rb
+++ b/lib/filterameter.rb
@@ -5,7 +5,7 @@ require 'zeitwerk'
 loader = Zeitwerk::Loader.for_gem
 loader.setup # ready!
 
-# = Filterameter
+# # Filterameter
 module Filterameter
   class << self
     attr_writer :configuration

--- a/lib/filterameter/configuration.rb
+++ b/lib/filterameter/configuration.rb
@@ -1,29 +1,33 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Configuration
+  # # Configuration
   #
   # Class Configuration stores the following settings:
-  # - action_on_undeclared_parameters
-  # - action_on_validation_failure
-  # - filter_key
+  # *   action_on_undeclared_parameters
+  # *   action_on_validation_failure
+  # *   filter_key
   #
-  # == Action on Undeclared Parameters
+  # ## Action on Undeclared Parameters
   #
-  # Occurs when the filter parameter contains any keys that are not defined. Valid actions are :log, :raise, and
-  # false (do not take action). By default, development will log, test will raise, and production will do nothing.
+  # Occurs when the filter parameter contains any keys that are not defined. Valid
+  # actions are :log, :raise, and false (do not take action). By default,
+  # development will log, test will raise, and production will do nothing.
   #
-  # == Action on Validation Failure
+  # ## Action on Validation Failure
   #
-  # Occurs when a filter parameter fails a validation. Valid actions are :log, :raise, and false (do not take action).
-  # By default, development will log, test will raise, and production will do nothing.
+  # Occurs when a filter parameter fails a validation. Valid actions are :log,
+  # :raise, and false (do not take action). By default, development will log, test
+  # will raise, and production will do nothing.
   #
-  # == Filter Key
+  # ## Filter Key
   #
-  # By default, the filter parameters are nested under the key :filter. Use this setting to override the key.
+  # By default, the filter parameters are nested under the key :filter. Use this
+  # setting to override the key.
   #
-  # If the filter parameters are NOT nested, set this to false. Doing so will restrict the filter parameters to only
-  # those that have been declared, meaning undeclared parameters are ignored (and the action_on_undeclared_parameters
+  # If the filter parameters are NOT nested, set this to false. Doing so will
+  # restrict the filter parameters to only those that have been declared, meaning
+  # undeclared parameters are ignored (and the action_on_undeclared_parameters
   # configuration option does not come into play).
   class Configuration
     attr_accessor :action_on_undeclared_parameters, :action_on_validation_failure, :filter_key

--- a/lib/filterameter/declaration_errors.rb
+++ b/lib/filterameter/declaration_errors.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module DeclarationErrors
-    # = Declaration Error
+    # # Declaration Error
     #
     # Error DeclarationError provides a base class for errors from filter or sort declarations.
     class DeclarationError < StandardError

--- a/lib/filterameter/declaration_errors/cannot_be_inline_scope_error.rb
+++ b/lib/filterameter/declaration_errors/cannot_be_inline_scope_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module DeclarationErrors
-    # = CannotBeInlineScopeError
+    # # Cannot Be Inline Scope Error
     #
     # Error CannotBeInlineScopeError occurs when an inline scope has been used to define a filter that takes a
     # parameter. This is not valid for use as a Filterameter filter because an inline scope always has an arity of -1

--- a/lib/filterameter/declaration_errors/filter_scope_argument_error.rb
+++ b/lib/filterameter/declaration_errors/filter_scope_argument_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module DeclarationErrors
-    # = Filter Scope Argument Error
+    # # Filter Scope Argument Error
     #
     # Error FilterScopeArgumentError occurs when a scope used as a filter but does not have either zero or one
     # arument. A conditional scope filter should take zero arguments; other scope filters should take one argument.

--- a/lib/filterameter/declaration_errors/no_such_attribute_error.rb
+++ b/lib/filterameter/declaration_errors/no_such_attribute_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module DeclarationErrors
-    # = No Such Attribute Error
+    # # No Such Attribute Error
     #
     # Error NoSuchAttributeError occurs when a filter or sort references an attribute that does not exist on the model.
     # The most likely case of this is a typo. Note that if the typo was supposed to reference a scope, this error is

--- a/lib/filterameter/declaration_errors/not_a_scope_error.rb
+++ b/lib/filterameter/declaration_errors/not_a_scope_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module DeclarationErrors
-    # = Not A Scope Error
+    # # Not A Scope Error
     #
     # Error NotAScopeError flags a class method that has been used as a filter but is not a scope. This could occur if
     # there is a class method of the same name an attribute, in which case the class method is going to block the

--- a/lib/filterameter/declaration_errors/sort_scope_requires_one_argument_error.rb
+++ b/lib/filterameter/declaration_errors/sort_scope_requires_one_argument_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module DeclarationErrors
-    # = Sort Scope Requires One Argument Error
+    # # Sort Scope Requires One Argument Error
     #
     # Error SortScopeRequiresOneArgumentError occurs when a sort has been declared for a scope that does not take
     # exactly one argument. Sort scopes must take a single argument and will receive either :asc or :desc to indicate

--- a/lib/filterameter/declaration_errors/unexpected_error.rb
+++ b/lib/filterameter/declaration_errors/unexpected_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module DeclarationErrors
-    # = Unexpected Error
+    # # Unexpected Error
     #
     # Error UnexpectedError occurs when the filter or scope factory raises an exception that the validator did not
     # expect.

--- a/lib/filterameter/declarations_validator.rb
+++ b/lib/filterameter/declarations_validator.rb
@@ -14,7 +14,8 @@ module Filterameter
   #
   # In Minitest it might look like this:
   #
-  #     assert WidgetsController.declarations_validator.valid?, WidgetsController.declarations_validator.errors
+  #     validator = WidgetsController.declarations_validator
+  #     assert_predicate validator, :valid?, -> { validator.errors }
   class DeclarationsValidator
     include Filterameter::Errors
 

--- a/lib/filterameter/declarations_validator.rb
+++ b/lib/filterameter/declarations_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Declarations Validator
+  # # Declarations Validator
   #
   # Class DeclarationsValidtor fetches each filter and sort from the registry to validate the declaration. This class
   # can be accessed from the controller as `declarations_validator` (via the FilterCoordinator) and be used in tests.
@@ -10,11 +10,11 @@ module Filterameter
   #
   # A test in RSpec might look like this:
   #
-  #   expect(WidgetsController.declarations_validator).to be_valid
+  #     expect(WidgetsController.declarations_validator).to be_valid
   #
   # In Minitest it might look like this:
   #
-  #   assert WidgetsController.declarations_validator.valid?, WidgetsController.declarations_validator.errors
+  #     assert WidgetsController.declarations_validator.valid?, WidgetsController.declarations_validator.errors
   class DeclarationsValidator
     include Filterameter::Errors
 
@@ -69,7 +69,7 @@ module Filterameter
       "\nInvalid #{type} for '#{name}':\n  #{errors.join("\n  ")}"
     end
 
-    # = Factory Errors
+    # # Factory Errors
     #
     # Class FactoryErrors is swapped in if the fetch from a factory fails. It is always invalid and provides the reason.
     class FactoryErrors

--- a/lib/filterameter/declarative_filters.rb
+++ b/lib/filterameter/declarative_filters.rb
@@ -26,6 +26,24 @@ module Filterameter
       end
     end
 
+    # Returns an ActiveRecord query from the filter parameters.
+    #
+    #     def index
+    #       @widgets = build_query_from_filters
+    #     end
+    #
+    # The method optionally takes a starting query. For example, this restricts the results
+    # to only active widgets:
+    #
+    #     def index
+    #       @widgets = build_query_from_filters(Widgets.where(active: true))
+    #     end
+    #
+    # The starting query can also be used to provide eager loading:
+    #
+    #     def index
+    #       @widgets = build_query_from_filters(Widgets.includes(:manufacturer))
+    #     end
     def build_query_from_filters(starting_query = nil)
       self.class.filter_coordinator.build_query(filter_parameters, starting_query)
     end

--- a/lib/filterameter/declarative_filters.rb
+++ b/lib/filterameter/declarative_filters.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Declarative Controller Filters
+  # # Declarative Controller Filters
   #
   # Mixin DeclarativeFilters should be included in controllers to enable the filter DSL.
   module DeclarativeFilters

--- a/lib/filterameter/errors.rb
+++ b/lib/filterameter/errors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Errors
+  # # Errors
   #
   # Module Errors provides `valid?` and `errors` to implementing classes. If the `valid?` method is not overridden,
   # then it returns true.

--- a/lib/filterameter/exceptions/cannot_determine_model_error.rb
+++ b/lib/filterameter/exceptions/cannot_determine_model_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Exceptions
-    # = Cannot Determine Model Error
+    # # Cannot Determine Model Error
     #
     # Class CannotDetermineModelError is raised when the model class cannot be determined from either the controller
     # name or controller path. This is a setup issue; the resolution is for the controller to specify the model class

--- a/lib/filterameter/exceptions/collection_association_sort_error.rb
+++ b/lib/filterameter/exceptions/collection_association_sort_error.rb
@@ -2,10 +2,10 @@
 
 module Filterameter
   module Exceptions
-    # = Collection Association Sort Error
+    # # Collection Association Sort Error
     #
-    # Class CollectionAssociationSortError is raised when a sort is attempted on a collection association. (Sorting is
-    # only valid on _singular_ associations.)
+    # Class CollectionAssociationSortError is raised when a sort is attempted on a
+    # collection association. (Sorting is only valid on *singular* associations.)
     class CollectionAssociationSortError < FilterameterError
       def initialize(declaration)
         super("Sorting is not allowed on collection associations: \n\t\t#{declaration}")

--- a/lib/filterameter/exceptions/invalid_association_declaration_error.rb
+++ b/lib/filterameter/exceptions/invalid_association_declaration_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Exceptions
-    # = Invalid Association Declaration Error
+    # # Invalid Association Declaration Error
     #
     # Class InvalidAssociationDeclarationError is raised when the declared association(s) are not valid.
     class InvalidAssociationDeclarationError < FilterameterError

--- a/lib/filterameter/exceptions/undeclared_parameter_error.rb
+++ b/lib/filterameter/exceptions/undeclared_parameter_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Exceptions
-    # = Undeclared Parameter Error
+    # # Undeclared Parameter Error
     #
     # Class UndeclaredParameterError is raised when a request contains filter parameters that have not been declared.
     # Configuration setting `action_on_undeclared_parameters` determines whether or not the exception is raised.

--- a/lib/filterameter/exceptions/validation_error.rb
+++ b/lib/filterameter/exceptions/validation_error.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Exceptions
-    # = Validation Error
+    # # Validation Error
     #
     # Class ValidationError is raised when a specified parameter fails a validation. Configuration setting
     # `action_on_validation_failure` determines whether or not the exception is raised.

--- a/lib/filterameter/filter_coordinator.rb
+++ b/lib/filterameter/filter_coordinator.rb
@@ -8,7 +8,7 @@ require 'action_controller/metal/live'
 require 'action_controller/metal/strong_parameters'
 
 module Filterameter
-  # = Filter Coordinator
+  # # Filter Coordinator
   #
   # Class FilterCoordinator stores the configuration declared via class-level method calls such as the list of
   # filters and the optionally declared model class. Each controller will have one instance of the coordinator

--- a/lib/filterameter/filter_declaration.rb
+++ b/lib/filterameter/filter_declaration.rb
@@ -3,7 +3,7 @@
 require 'active_support/core_ext/array/wrap'
 
 module Filterameter
-  # = Filter Declaration
+  # # Filter Declaration
   #
   # Class FilterDeclaration captures the filter declaration within the controller.
   #

--- a/lib/filterameter/filter_factory.rb
+++ b/lib/filterameter/filter_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Filter Factory
+  # # Filter Factory
   #
   # Class FilterFactory builds a filter from a FilterDeclaration.
   class FilterFactory

--- a/lib/filterameter/filterable.rb
+++ b/lib/filterameter/filterable.rb
@@ -1,52 +1,65 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Declarative Filters
+  # # Declarative Filters
   #
-  # Mixin Filterable provides class methods <tt>filter</tt> and <tt>filters</tt>.
+  # Mixin Filterable provides class methods `filter` and `filters`.
   module Filterable
     extend ActiveSupport::Concern
 
     class_methods do
-      # Declares a filter that can be read from the parameters and applied to the ActiveRecord query. The <tt>name</tt>
-      # identifies the name of the parameter and is the default value to determine the criteria to be applied. The name
-      # can be either an attribute or a scope.
+      # Declares a filter that can be read from the parameters and applied to the
+      # ActiveRecord query. The `name` identifies the name of the parameter and is the
+      # default value to determine the criteria to be applied. The name can be either
+      # an attribute or a scope.
       #
-      # === Options
+      # ### Options
       #
-      # [:name]
-      #   Specify the attribute or scope name if the parameter name is not the same. The default value
-      #   is the parameter name, so if the two match this can be left out.
+      # :name
+      # :   Specify the attribute or scope name if the parameter name is not the same.
+      #     The default value is the parameter name, so if the two match this can be
+      #     left out.
       #
-      # [:association]
-      #   Specify the name of the association if the attribute or scope is nested.
       #
-      # [:validates]
-      #   Specify a validation if the parameter value should be validated. This uses ActiveModel validations;
-      #   please review those for types of validations and usage.
+      # :association
+      # :   Specify the name of the association if the attribute or scope is nested.
       #
-      # [:partial]
-      #   Specify the partial option if the filter should do a partial search (SQL's `LIKE`). The partial
-      #   option accepts a hash to specify the search behavior. Here are the available options:
-      #   - match: anywhere (default), from_start, dynamic
-      #   - case_sensitive: true, false (default)
       #
-      #   There are two shortcuts: : the partial option can be declared with `true`, which just uses the
-      #   defaults; or the partial option can be declared with the match option directly,
-      #   such as `partial: :from_start`.
+      # :validates
+      # :   Specify a validation if the parameter value should be validated. This uses
+      #     ActiveModel validations; please review those for types of validations and
+      #     usage.
       #
-      # [:range]
-      #   Specify a range option if the filter also allows ranges to be searched. The range option accepts
-      #   the following options:
-      #   - true: enables two additional parameters with attribute name plus suffixes <tt>_min</tt> and <tt>_max</tt>
-      #   - :min_only: enables additional parameter with attribute name plus suffix <tt>_min</tt>
-      #   - :max_only: enables additional parameter with attribute name plus suffix <tt>_max</tt>
+      #
+      # :partial
+      # :   Specify the partial option if the filter should do a partial search (SQL's
+      #     `LIKE`). The partial option accepts a hash to specify the search behavior.
+      #     Here are the available options:
+      #     *   match: anywhere (default), from_start, dynamic
+      #     *   case_sensitive: true, false (default)
+      #
+      #     There are two shortcuts: : the partial option can be declared with `true`,
+      #     which just uses the defaults; or the partial option can be declared with
+      #     the match option directly, such as `partial: :from_start`.
+      #
+      #
+      # :range
+      # :   Specify a range option if the filter also allows ranges to be searched.
+      #     The range option accepts the following options:
+      #     *   true: enables two additional parameters with attribute name plus
+      #         suffixes `_min` and `_max`
+      #     *   :min_only: enables additional parameter with attribute name plus
+      #         suffix `_min`
+      #     *   :max_only: enables additional parameter with attribute name plus
+      #         suffix `_max`
+      #
       def filter(name, options = {})
         filter_coordinator.add_filter(name, options)
       end
 
-      # Declares a list of filters that can be read from the parameters and applied to the query. The name can be either
-      # an attribute or a scope. Declare filters individually with <tt>filter</tt> if more options are required.
+      # Declares a list of filters that can be read from the parameters and applied to
+      # the query. The name can be either an attribute or a scope. Declare filters
+      # individually with `filter` if more options are required.
       def filters(*names)
         names.each { |name| filter(name) }
       end

--- a/lib/filterameter/filters/arel_filter.rb
+++ b/lib/filterameter/filters/arel_filter.rb
@@ -2,9 +2,10 @@
 
 module Filterameter
   module Filters
-    # = Arel Filter
+    # # Arel Filter
     #
-    # Class ArelFilter is a base class for arel queries. It does not implement <tt>apply</tt>.
+    # Class ArelFilter is a base class for arel queries. It does not implement
+    # `apply`.
     class ArelFilter
       include Filterameter::Errors
       include Filterameter::Filters::AttributeValidator

--- a/lib/filterameter/filters/attribute_filter.rb
+++ b/lib/filterameter/filters/attribute_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Attribute Filter
+    # # Attribute Filter
     #
     # Class AttributeFilter leverages ActiveRecord's where query method to add criteria for an attribute.
     class AttributeFilter

--- a/lib/filterameter/filters/attribute_validator.rb
+++ b/lib/filterameter/filters/attribute_validator.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Attribute Validator
+    # # Attribute Validator
     #
     # Module AttributeValidator validates that the attribute exists on the model.
     module AttributeValidator

--- a/lib/filterameter/filters/conditional_scope_filter.rb
+++ b/lib/filterameter/filters/conditional_scope_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Conditional Scope Filter
+    # # Conditional Scope Filter
     #
     # Class ConditionalScopeFilter applies the scope if the parameter is not false.
     class ConditionalScopeFilter

--- a/lib/filterameter/filters/matches_filter.rb
+++ b/lib/filterameter/filters/matches_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Matches Filter
+    # # Matches Filter
     #
     # Class MatchesFilter uses arel's `matches` to generate a LIKE query.
     class MatchesFilter

--- a/lib/filterameter/filters/maximum_filter.rb
+++ b/lib/filterameter/filters/maximum_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Maximum Filter
+    # # Maximum Filter
     #
     # Class MaximumFilter adds criteria for all values greater than or equal to a maximum.
     class MaximumFilter < ArelFilter

--- a/lib/filterameter/filters/minimum_filter.rb
+++ b/lib/filterameter/filters/minimum_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Minimum Filter
+    # # Minimum Filter
     #
     # Class MinimumFilter adds criteria for all values greater than or equal to a minimum.
     class MinimumFilter < ArelFilter

--- a/lib/filterameter/filters/nested_collection_filter.rb
+++ b/lib/filterameter/filters/nested_collection_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Nested Collection Filter
+    # # Nested Collection Filter
     #
     # Class NestedCollectionFilter joins the nested table(s), merges the filter to the association's model, then makes
     # the results distinct.

--- a/lib/filterameter/filters/nested_filter.rb
+++ b/lib/filterameter/filters/nested_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Nested Attribute Filter
+    # # Nested Attribute Filter
     #
     # Class NestedFilter joins the nested table(s) then merges the filter to the association's model.
     class NestedFilter

--- a/lib/filterameter/filters/scope_filter.rb
+++ b/lib/filterameter/filters/scope_filter.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Filters
-    # = Scope Filter
+    # # Scope Filter
     #
     # Class ScopeFilter applies the named scope passing in the parameter value.
     class ScopeFilter

--- a/lib/filterameter/helpers/declaration_with_model.rb
+++ b/lib/filterameter/helpers/declaration_with_model.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Helpers
-    # = Declaration with Model
+    # # Declaration with Model
     #
     # Class DeclarationWithModel inspects the declaration under the context of the model. This enables
     # predicate methods as well as drilling through associations.

--- a/lib/filterameter/helpers/joins_values_builder.rb
+++ b/lib/filterameter/helpers/joins_values_builder.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Helpers
-    # = Joins Values Builder
+    # # Joins Values Builder
     #
     # Class JoinsValuesBuilder evaluates an array of names to return either the single entry when there is only
     # one element in the array or a nested hash when there is more than one element. This is the argument that is

--- a/lib/filterameter/helpers/requested_sort.rb
+++ b/lib/filterameter/helpers/requested_sort.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Helpers
-    # = Reqested Sort
+    # # Reqested Sort
     #
     # Class RequestedSort parses the name and direction from a sort segment.
     class RequestedSort

--- a/lib/filterameter/log_subscriber.rb
+++ b/lib/filterameter/log_subscriber.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Log Subscriber
+  # # Log Subscriber
   #
   # Class LogSubscriber provides instrumentation for events.
   class LogSubscriber < ActiveSupport::LogSubscriber

--- a/lib/filterameter/options/partial_options.rb
+++ b/lib/filterameter/options/partial_options.rb
@@ -2,19 +2,20 @@
 
 module Filterameter
   module Options
-    # = Partial Options
+    # # Partial Options
     #
-    # Class PartialOptions parses the options passed in as partial, then exposes those. Here are the options along with
-    # their valid values:
-    # - match: anywhere (default), from_start, dynamic
-    # - case_sensitive: true, false (default)
+    # Class PartialOptions parses the options passed in as partial, then exposes
+    # those. Here are the options along with their valid values:
+    # *   match: anywhere (default), from_start, dynamic
+    # *   case_sensitive: true, false (default)
     #
     # Options may be specified by passing a hash with the option keys:
     #
-    #   partial: { match: :from_start, case_sensitive: true }
+    #     partial: { match: :from_start, case_sensitive: true }
     #
-    # There are two shortcuts: the partial option can be declared with `true`, which just uses the defaults; or the
-    # partial option can be declared with the match option directly, such as partial: :from_start.
+    # There are two shortcuts: the partial option can be declared with `true`, which
+    # just uses the defaults; or the partial option can be declared with the match
+    # option directly, such as partial: :from_start.
     class PartialOptions
       VALID_OPTIONS = %i[match case_sensitive].freeze
       VALID_MATCH_OPTIONS = %w[anywhere from_start dynamic].freeze

--- a/lib/filterameter/parameters_base.rb
+++ b/lib/filterameter/parameters_base.rb
@@ -4,7 +4,7 @@ require 'active_model/attribute_assignment'
 require 'active_model/validations'
 
 module Filterameter
-  # = Parameters
+  # # Parameters
   #
   # Class Parameters is sub-classed to provide controller-specific validations.
   class ParametersBase

--- a/lib/filterameter/query_builder.rb
+++ b/lib/filterameter/query_builder.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Query Builder
+  # # Query Builder
   #
   # Class Query Builder turns filter parameters into a query.
   #
   # The query builder is instantiated by the filter coordinator. The default query currently is simple `all`. The
   # default sort comes for the controller declaration of the same name; it is optional and the value may be nil.
   #
-  # If the request includes a sort, it is always applied. If not, the following logic kicks in to provide a sort:
-  # - if the starting query includes a sort, no additional sort is applied
-  # - if a default sort has been declared, it is applied
-  # - if neither of those provides a sort, then the fallback is primary key desc
+  # If the request includes a sort, it is always applied. If not, the following
+  # logic kicks in to provide a sort:
+  # *   if the starting query includes a sort, no additional sort is applied
+  # *   if a default sort has been declared, it is applied
+  # *   if neither of those provides a sort, then the fallback is primary key desc
   class QueryBuilder
     def initialize(default_query, default_sort, filter_registry)
       @default_query = default_query
@@ -87,9 +88,10 @@ module Filterameter
       end
     end
 
-    # TODO: this handles any runtime exceptions, not just undeclared parameter errors:
-    # - should the config option be more generalized?
-    # - or should there be a config option for each type of error?
+    # TODO: this handles any runtime exceptions, not just undeclared parameter
+    # errors:
+    # *   should the config option be more generalized?
+    # *   or should there be a config option for each type of error?
     def handle_undeclared_parameter(exception)
       action = Filterameter.configuration.action_on_undeclared_parameters
       return unless action

--- a/lib/filterameter/registries/filter_registry.rb
+++ b/lib/filterameter/registries/filter_registry.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Registries
-    # Filters
+    # # Filter Registry
     #
     # Class FilterRegistry is a collection of the filters. It captures the filter declarations when classes are loaded,
     # then uses the injected FilterFactory to build the filters on demand as they are needed.

--- a/lib/filterameter/registries/registry.rb
+++ b/lib/filterameter/registries/registry.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Registries
-    # = Registry
+    # # Registry
     #
     # Class Registry records declarations and allows resulting filters and sorts to be fetched from sub-registries.
     class Registry

--- a/lib/filterameter/registries/sort_registry.rb
+++ b/lib/filterameter/registries/sort_registry.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Registries
-    # Sort Registry
+    # # Sort Registry
     #
     # Class SortRegistry is a collection of the sorts. It captures the declarations when classes are loaded,
     # then uses the injected SortFactory to build the sorts on demand as they are needed.

--- a/lib/filterameter/registries/sub_registry.rb
+++ b/lib/filterameter/registries/sub_registry.rb
@@ -2,12 +2,11 @@
 
 module Filterameter
   module Registries
-    # SubRegistry
+    # # SubRegistry
     #
     # Class SubRegistry provides add and fetch methods as well as the initialization for sub-registries.
     #
     # Subclasses must implement build_declaration.
-    #
     class SubRegistry
       def initialize(factory)
         @factory = factory

--- a/lib/filterameter/sort_declaration.rb
+++ b/lib/filterameter/sort_declaration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Sort Declaration
+  # # Sort Declaration
   #
   # Class SortDeclaration captures the sort declaration within the controller. A sort declaration is also generated
   # from a FilterDeclaration when it is `sortable?`.

--- a/lib/filterameter/sort_factory.rb
+++ b/lib/filterameter/sort_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Sort Factory
+  # # Sort Factory
   #
   # Class SortFactory builds a sort from a model and a declaration.
   class SortFactory

--- a/lib/filterameter/sortable.rb
+++ b/lib/filterameter/sortable.rb
@@ -1,33 +1,38 @@
 # frozen_string_literal: true
 
 module Filterameter
-  # = Sortable
+  # # Sortable
   #
-  # Mixin Sortable provides class methods <tt>sort</tt> and <tt>sorts</tt>.
+  # Mixin Sortable provides class methods `sort` and `sorts`.
   module Sortable
     extend ActiveSupport::Concern
 
     class_methods do
-      # Declares a sort that can be read from the parameters and applied to the ActiveRecord query. The
-      # <tt>parameter_name</tt> identifies the name of the parameter and is the default value for the attribute
-      # name when none is specified in the options.
+      # Declares a sort that can be read from the parameters and applied to the
+      # ActiveRecord query. The `parameter_name` identifies the name of the parameter
+      # and is the default value for the attribute name when none is specified in the
+      # options.
       #
       # The including class must implement `filter_coordinator`
       #
-      # === Options
+      # ### Options
       #
-      # [:name]
-      #   Specify the attribute or scope name if the parameter name is not the same. The default value
-      #   is the parameter name, so if the two match this can be left out.
+      # :name
+      # :   Specify the attribute or scope name if the parameter name is not the same.
+      #     The default value is the parameter name, so if the two match this can be
+      #     left out.
       #
-      # [:association]
-      #   Specify the name of the association if the attribute or scope is nested.
+      #
+      # :association
+      # :   Specify the name of the association if the attribute or scope is nested.
+      #
       def sort(parameter_name, options = {})
         filter_coordinator.add_sort(parameter_name, options)
       end
 
-      # Declares a list of filters that can be read from the parameters and applied to the query. The name can be either
-      # an attribute or a scope. Declare filters individually with <tt>filter</tt> if more options are required.
+      # Declares a list of filters that can be read from the parameters and applied to
+      # the query. The name can be either an attribute or a scope. Declare filters
+      # individually with `filter` if more options are required.
       def sorts(*parameter_names)
         parameter_names.each { |parameter_name| filter(parameter_name) }
       end

--- a/lib/filterameter/sorts/attribute_sort.rb
+++ b/lib/filterameter/sorts/attribute_sort.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Sorts
-    # = Attribute Sort
+    # # Attribute Sort
     #
     # Class AttributeSort leverages ActiveRecord's `order` query method to add sorting for an attribute.
     class AttributeSort

--- a/lib/filterameter/sorts/scope_sort.rb
+++ b/lib/filterameter/sorts/scope_sort.rb
@@ -2,7 +2,7 @@
 
 module Filterameter
   module Sorts
-    # = Scope Sort
+    # # Scope Sort
     #
     # Class ScopeSort applies the scope with the a param that is either :asc or :desc. A scope that does not take
     # exactly one argument is not valid for sorting.

--- a/lib/filterameter/validators/inclusion_validator.rb
+++ b/lib/filterameter/validators/inclusion_validator.rb
@@ -2,14 +2,14 @@
 
 module Filterameter
   module Validators
-    # = Inclusion Validator
+    # # Inclusion Validator
     #
     # Class InclusionValidator extends ActiveModel::Validations::InclusionValidator to enable validations of multiple
     # values.
     #
-    # == Example
+    # ## Example
     #
-    #   validates: { inclusion: { in: %w[Small Medium Large], allow_multiple_values: true } }
+    #     validates: { inclusion: { in: %w[Small Medium Large], allow_multiple_values: true } }
     #
     class InclusionValidator < ActiveModel::Validations::InclusionValidator
       def validate_each(record, attribute, value)


### PR DESCRIPTION
The hover previews in IDE's generally render markdown. RDoc can also be generated from markdown, so that appears to be the better choice, as well as the emerging Rails standard:

https://github.com/rails/rails/issues/50759