### PR TITLE
Add Ruby 3.4 to test matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.1', '3.2', '3.3']
+        ruby: ['3.1', '3.2', '3.3', '3.4']
         gemfile:
           - rails_6_1
           - rails_7

--- a/Appraisals
+++ b/Appraisals
@@ -4,11 +4,17 @@ appraise 'rails-6-1' do
   gem 'rails', '~> 6.1.0'
   gem 'rspec-rails', '~> 6.1'
   gem 'base64'
+  gem 'bigdecimal'
+  gem 'drb'
+  gem 'mutex_m'
 end
 
 appraise 'rails-7' do
   gem 'rails', '~> 7.0.0'
   gem 'base64'
+  gem 'bigdecimal'
+  gem 'drb'
+  gem 'mutex_m'
 end
 
 appraise 'rails-7-1' do

--- a/Appraisals
+++ b/Appraisals
@@ -3,10 +3,12 @@
 appraise 'rails-6-1' do
   gem 'rails', '~> 6.1.0'
   gem 'rspec-rails', '~> 6.1'
+  gem 'base64'
 end
 
 appraise 'rails-7' do
   gem 'rails', '~> 7.0.0'
+  gem 'base64'
 end
 
 appraise 'rails-7-1' do

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
 gem "rspec-rails", "~> 6.1"
+gem "base64"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -5,5 +5,8 @@ source "https://rubygems.org"
 gem "rails", "~> 6.1.0"
 gem "rspec-rails", "~> 6.1"
 gem "base64"
+gem "bigdecimal"
+gem "drb"
+gem "mutex_m"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem "base64"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -4,5 +4,8 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
 gem "base64"
+gem "bigdecimal"
+gem "drb"
+gem "mutex_m"
 
 gemspec path: "../"


### PR DESCRIPTION
There are some gems that were removed for the ruby standard library in 3.4. Recent rails have added those as dependencies. Rails 6.1 and 7.0 did not include those, so to run with ruby 3.4 they had to be added manually.

This won't be an issue for Filterameter, as anyone running rails 6.1 or 7.0 will also need to do this to get rails to work.