### PR TITLE
Ignore empty filters

### DIFF
--- a/lib/filterameter/query_builder.rb
+++ b/lib/filterameter/query_builder.rb
@@ -30,7 +30,9 @@ module Filterameter
 
     def parse_filter_params(filter_params)
       sort = parse_sorts(filter_params.delete('sort'))
-      [sort, remove_invalid_values(filter_params)]
+      params = filter_params.reject { |_k, v| v.is_a?(String) && v.empty? }
+                            .then { |p| remove_invalid_values(p) }
+      [sort, params]
     end
 
     def parse_sorts(sorts)

--- a/spec/dummy/app/controllers/tasks_controller.rb
+++ b/spec/dummy/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TasksController < ApplicationController
+  filter :completed
   filter :description, partial: true
   filter :description_starts_with, name: :description, partial: :from_start
   filter :description_case_sensitive, name: :description, partial: { case_sensitive: true }

--- a/spec/requests/attribute_filters_spec.rb
+++ b/spec/requests/attribute_filters_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Attribute filters' do
-  fixtures :activities, :users
+  fixtures :activities, :users, :tasks
 
   context 'with no options' do
     before { get '/activities', params: { filter: { activity_manager_id: users(:joe_jackson).id } } }
@@ -68,6 +68,44 @@ RSpec.describe 'Attribute filters' do
     it 'returns the correct number of rows' do
       count = Activity.where(activity_manager_id: users(:joe_jackson).id).count
       expect(response.parsed_body.size).to eq count
+    end
+  end
+
+  context 'with boolean filter set to true' do
+    before { get '/tasks', params: { filter: { completed: true } } }
+
+    it 'returns the correct number of rows' do
+      count = Task.where(completed: true).count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'returns Grind coffee beans' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('description' => tasks(:grind_coffee_beans).description)
+    end
+
+    it 'does not return Make toast' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).not_to include_a_record_with('description' => tasks(:make_toast).description)
+    end
+  end
+
+  context 'with boolean filter set to false' do
+    before { get '/tasks', params: { filter: { completed: false } } }
+
+    it 'returns the correct number of rows' do
+      count = Task.where(completed: false).count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'does not return Grind coffee beans' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).not_to include_a_record_with('description' => tasks(:grind_coffee_beans).description)
+    end
+
+    it 'returns Make toast' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('description' => tasks(:make_toast).description)
     end
   end
 end

--- a/spec/requests/attribute_filters_spec.rb
+++ b/spec/requests/attribute_filters_spec.rb
@@ -61,4 +61,13 @@ RSpec.describe 'Attribute filters' do
         .to raise_exception(Filterameter::Exceptions::ValidationError)
     end
   end
+
+  context 'with empty filters' do
+    before { get '/activities', params: { filter: { manager_id: users(:joe_jackson).id, activity_manager_id: '' } } }
+
+    it 'returns the correct number of rows' do
+      count = Activity.where(activity_manager_id: users(:joe_jackson).id).count
+      expect(response.parsed_body.size).to eq count
+    end
+  end
 end


### PR DESCRIPTION
In a standard search form, with all the possible criteria as form fields, they all get passed by Rails whether they have values or not. This excludes empty filters.

Normally the params are all string values: so False is "false" and True is "true" as parameters. There are some edge cases where params can be added in the controller; in that case they might be True or False. Since `False.empty?` is true, the check is first done to make sure the value is a string before checking to see if it is empty.

Fixes #149.