### PR TITLE
Simplecov Configuration

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'simplecov'
 
 SimpleCov.start do
   add_filter 'spec/'
+  enable_coverage :branch
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
- filter out spec files
- enable branch coverage

This makes the coverage more accurate and shows a couple of spots without tests.

<img width="578" height="122" alt="image" src="https://github.com/user-attachments/assets/987c587b-1d3a-42ca-8f43-c534e1adc5b6" />
