### PR TITLE
Declare converters with filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Simplify and speed development of Rails controllers by making filter parameters 
     - [Partial](#partial)
     - [Range](#range)
     - [Sortable](#sortable)
+    - [Converters](#converters)
   - [Scope Filters](#scope-filters)
   - [Sorting](#sorting)
   - [Building the Query](#building-the-query)
@@ -82,6 +83,9 @@ Include module `Filterameter::DeclarativeFilters` in the controller to provide t
   filter :brand_name, association: :brand, name: :name
   filter :on_sale, association: :price, validates: [{ numericality: { greater_than: 0 } },
                                                     { numericality: { less_than: 100 } }]
+  filter :amount do |value|
+    value.is_a?(String) ? value.delete(",") : value
+  end
 ```
 
 Filters without options can be declared all at once with `filters`:
@@ -185,6 +189,17 @@ The following filters are not sortable:
 - scope filters (see [_Sorting with a Scope_](#sorting-with-a-scope))
 - filters with collection associations
 
+#### Converters
+
+If the filter value needs to be converted before being applied to the query, a converter block can be provided. The block should take the parameter value as an argument and return the converted value.
+
+For example, if the amount filter should remove commas from the value before applying it to the query, the declaration would look like this:
+
+```ruby
+filter :amount do |value|
+  value.is_a?(String) ? value.delete(",") : value
+end
+```
 
 ### Scope Filters
 

--- a/lib/filterameter/declarative_filters.rb
+++ b/lib/filterameter/declarative_filters.rb
@@ -61,8 +61,8 @@ module Filterameter
       #     filter :department_name, partial: :from_start
       #     filter :reason, partial: { match: :dynamic, case_sensitive: true }
       #     filter :price, range: true
-      def filter(name, options = {})
-        filter_coordinator.add_filter(name, options)
+      def filter(name, options = {}, &converter)
+        filter_coordinator.add_filter(name, options.merge(converter:))
       end
 
       # Declares a list of filters without options. Filters that require options must be declared with `filter`.

--- a/lib/filterameter/filter_declaration.rb
+++ b/lib/filterameter/filter_declaration.rb
@@ -16,7 +16,7 @@ module Filterameter
   class FilterDeclaration
     VALID_RANGE_OPTIONS = [true, :min_only, :max_only].freeze
 
-    attr_reader :name, :parameter_name, :association, :validations
+    attr_reader :name, :parameter_name, :association, :validations, :converter
 
     def initialize(parameter_name, options, range_type: nil)
       @parameter_name = parameter_name.to_s
@@ -29,6 +29,7 @@ module Filterameter
       @raw_range = options[:range]
       @range_type = range_type
       @sortable = options.fetch(:sortable, true)
+      @converter = options[:converter]
     end
 
     def nested?
@@ -88,7 +89,7 @@ module Filterameter
     private
 
     def validate_options(options)
-      options.assert_valid_keys(:name, :association, :validates, :partial, :range, :sortable)
+      options.assert_valid_keys(:name, :association, :validates, :partial, :range, :sortable, :converter)
       validate_range(options[:range]) if options.key?(:range)
     end
 

--- a/lib/filterameter/filter_factory.rb
+++ b/lib/filterameter/filter_factory.rb
@@ -15,7 +15,7 @@ module Filterameter
       if declaration.nested?
         build_nested_filter(declaration, context)
       else
-        build_filter(@model_class, declaration, context.scope?)
+        build_filter_or_scope_filter(@model_class, declaration, context.scope?)
       end
     end
 
@@ -23,23 +23,29 @@ module Filterameter
 
     def build_nested_filter(declaration, context)
       model = context.model_from_association
-      filter = build_filter(model, declaration, context.scope?)
+      filter = build_filter_or_scope_filter(model, declaration, context.scope?)
       nested_filter_class = context.any_collections? ? Filters::NestedCollectionFilter : Filters::NestedFilter
 
       nested_filter_class.new(declaration.association, model, filter)
     end
 
-    def build_filter(model, declaration, declaration_is_a_scope) # rubocop:disable Metrics/MethodLength
+    def build_filter_or_scope_filter(model, declaration, declaration_is_a_scope)
       if declaration_is_a_scope
         build_scope_filter(model, declaration)
-      elsif declaration.partial_search?
-        Filterameter::Filters::MatchesFilter.new(declaration.name, declaration.partial_options)
-      elsif declaration.minimum_range?
-        Filterameter::Filters::MinimumFilter.new(model, declaration.name)
-      elsif declaration.maximum_range?
-        Filterameter::Filters::MaximumFilter.new(model, declaration.name)
       else
-        Filterameter::Filters::AttributeFilter.new(declaration.name)
+        build_filter(model, declaration)
+      end
+    end
+
+    def build_filter(model, declaration)
+      if declaration.partial_search?
+        Filterameter::Filters::MatchesFilter.new(declaration.name, declaration.partial_options, &declaration.converter)
+      elsif declaration.minimum_range?
+        Filterameter::Filters::MinimumFilter.new(model, declaration.name, &declaration.converter)
+      elsif declaration.maximum_range?
+        Filterameter::Filters::MaximumFilter.new(model, declaration.name, &declaration.converter)
+      else
+        Filterameter::Filters::AttributeFilter.new(declaration.name, &declaration.converter)
       end
     end
 
@@ -48,9 +54,9 @@ module Filterameter
     def build_scope_filter(model, declaration)
       number_of_arguments = model.method(declaration.name).arity
       if number_of_arguments < 1
-        Filterameter::Filters::ConditionalScopeFilter.new(declaration.name)
+        Filterameter::Filters::ConditionalScopeFilter.new(declaration.name, &declaration.converter)
       elsif number_of_arguments == 1
-        Filterameter::Filters::ScopeFilter.new(declaration.name)
+        Filterameter::Filters::ScopeFilter.new(declaration.name, &declaration.converter)
       else
         raise Filterameter::DeclarationErrors::FilterScopeArgumentError.new(model.name, declaration.name)
       end

--- a/lib/filterameter/filters/arel_filter.rb
+++ b/lib/filterameter/filters/arel_filter.rb
@@ -10,9 +10,10 @@ module Filterameter
       include Filterameter::Errors
       include Filterameter::Filters::AttributeValidator
 
-      def initialize(model, attribute_name)
+      def initialize(model, attribute_name, &converter)
         @attribute_name = attribute_name
         @arel_attribute = model.arel_table[attribute_name]
+        @converter = converter
       end
     end
   end

--- a/lib/filterameter/filters/attribute_filter.rb
+++ b/lib/filterameter/filters/attribute_filter.rb
@@ -9,11 +9,13 @@ module Filterameter
       include Filterameter::Errors
       include AttributeValidator
 
-      def initialize(attribute_name)
+      def initialize(attribute_name, &converter)
         @attribute_name = attribute_name
+        @converter = converter
       end
 
       def apply(query, value)
+        value = @converter.call(value) if @converter
         query.where(@attribute_name => value)
       end
     end

--- a/lib/filterameter/filters/conditional_scope_filter.rb
+++ b/lib/filterameter/filters/conditional_scope_filter.rb
@@ -8,11 +8,13 @@ module Filterameter
     class ConditionalScopeFilter
       include Filterameter::Errors
 
-      def initialize(scope_name)
+      def initialize(scope_name, &converter)
         @scope_name = scope_name
+        @converter = converter
       end
 
       def apply(query, value)
+        value = @converter.call(value) if @converter
         return query unless ActiveModel::Type::Boolean.new.cast(value)
 
         query.public_send(@scope_name)

--- a/lib/filterameter/filters/matches_filter.rb
+++ b/lib/filterameter/filters/matches_filter.rb
@@ -9,14 +9,16 @@ module Filterameter
       include Filterameter::Errors
       include Filterameter::Filters::AttributeValidator
 
-      def initialize(attribute_name, options)
+      def initialize(attribute_name, options, &converter)
         @attribute_name = attribute_name
         @prefix = options.match_anywhere? ? '%' : nil
         @suffix = options.match_anywhere? || options.match_from_start? ? '%' : nil
         @case_sensitive = options.case_sensitive?
+        @converter = converter
       end
 
       def apply(query, value)
+        value = @converter.call(value) if @converter
         arel = query.arel_table[@attribute_name].matches("#{@prefix}#{value}#{@suffix}", false, @case_sensitive)
         query.where(arel)
       end

--- a/lib/filterameter/filters/maximum_filter.rb
+++ b/lib/filterameter/filters/maximum_filter.rb
@@ -7,6 +7,7 @@ module Filterameter
     # Class MaximumFilter adds criteria for all values greater than or equal to a maximum.
     class MaximumFilter < ArelFilter
       def apply(query, value)
+        value = @converter.call(value) if @converter
         query.where(@arel_attribute.lteq(value))
       end
     end

--- a/lib/filterameter/filters/minimum_filter.rb
+++ b/lib/filterameter/filters/minimum_filter.rb
@@ -7,6 +7,7 @@ module Filterameter
     # Class MinimumFilter adds criteria for all values greater than or equal to a minimum.
     class MinimumFilter < ArelFilter
       def apply(query, value)
+        value = @converter.call(value) if @converter
         query.where(@arel_attribute.gteq(value))
       end
     end

--- a/lib/filterameter/filters/scope_filter.rb
+++ b/lib/filterameter/filters/scope_filter.rb
@@ -8,11 +8,13 @@ module Filterameter
     class ScopeFilter
       include Filterameter::Errors
 
-      def initialize(scope_name)
+      def initialize(scope_name, &converter)
         @scope_name = scope_name
+        @converter = converter
       end
 
       def apply(query, value)
+        value = @converter.call(value) if @converter
         query.public_send(@scope_name, value)
       end
 

--- a/spec/dummy/app/controllers/activities_controller.rb
+++ b/spec/dummy/app/controllers/activities_controller.rb
@@ -6,6 +6,9 @@ class ActivitiesController < ApplicationController
   filter :activity_manager_id
   filter :manager_id, name: :activity_manager_id
   filter :incomplete
+  filter :yes_no_incomplete, name: :incomplete do |value|
+    value == 'YES'
+  end
   filter :in_progress, name: :incomplete
   filter :task_count, range: true
   filter :min_only_task_count, name: :task_count, range: :min_only

--- a/spec/dummy/app/controllers/activities_controller.rb
+++ b/spec/dummy/app/controllers/activities_controller.rb
@@ -11,6 +11,9 @@ class ActivitiesController < ApplicationController
   end
   filter :in_progress, name: :incomplete
   filter :task_count, range: true
+  filter :task_count_with_comma, name: :task_count, range: true do |value|
+    value.to_s.delete(',').to_i
+  end
   filter :min_only_task_count, name: :task_count, range: :min_only
   filter :max_only_task_count, name: :task_count, range: :max_only
   filter :project_priority, name: :priority, association: :project

--- a/spec/dummy/app/controllers/projects_controller.rb
+++ b/spec/dummy/app/controllers/projects_controller.rb
@@ -7,6 +7,9 @@ class ProjectsController < ApplicationController
   filter :with_inactive_activity_manager, name: :inactive, association: %i[activities activity_manager]
   filter :with_incomplete_tasks, name: :incomplete, association: %i[activities tasks]
   filter :in_progress
+  filter :in_progress_as_of_days_ago, name: :in_progress do |value|
+    Date.current - value.to_i.days
+  end
 
   sort :by_created_at
   sort :by_project_id

--- a/spec/dummy/app/controllers/tasks_controller.rb
+++ b/spec/dummy/app/controllers/tasks_controller.rb
@@ -2,6 +2,9 @@
 
 class TasksController < ApplicationController
   filter :completed
+  filter :yes_no_completed, name: :completed do |value|
+    value == 'YES'
+  end
   filter :description, partial: true
   filter :description_starts_with, name: :description, partial: :from_start
   filter :description_case_sensitive, name: :description, partial: { case_sensitive: true }

--- a/spec/filterameter/filter_declaration_spec.rb
+++ b/spec/filterameter/filter_declaration_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Filterameter::FilterDeclaration do
     it('#partial_match?') { expect(declaration.partial_search?).to be false }
     it('#sortable?') { expect(declaration.sortable?).to be true }
     it('#to_s') { expect(declaration.to_s).to eq 'filter :size' }
+    it('#converter') { expect(declaration.converter).to be_nil }
   end
 
   context 'with name specified' do

--- a/spec/filterameter/filter_declaration_spec.rb
+++ b/spec/filterameter/filter_declaration_spec.rb
@@ -111,4 +111,11 @@ RSpec.describe Filterameter::FilterDeclaration do
       expect { declaration }.to raise_error(ArgumentError)
     end
   end
+
+  context 'with converter' do
+    let(:converter) { ->(value) { value.to_i } }
+    let(:declaration) { described_class.new(:size, { converter: converter }) }
+
+    it('#converter') { expect(declaration.converter).to eq converter }
+  end
 end

--- a/spec/filterameter/filters/attribute_filter_spec.rb
+++ b/spec/filterameter/filters/attribute_filter_spec.rb
@@ -29,4 +29,15 @@ RSpec.describe Filterameter::Filters::AttributeFilter do
         .to contain_exactly Filterameter::DeclarationErrors::NoSuchAttributeError.new('Activity', :not_a_thing)
     end
   end
+
+  context 'with converter' do
+    let(:filter) { described_class.new(:color, &:upcase) }
+
+    it 'applies converter to value' do
+      query = class_spy(ActiveRecord::Base)
+
+      filter.apply(query, 'blue')
+      expect(query).to have_received(:where).with(color: 'BLUE')
+    end
+  end
 end

--- a/spec/filterameter/filters/conditional_scope_filter_spec.rb
+++ b/spec/filterameter/filters/conditional_scope_filter_spec.rb
@@ -53,4 +53,18 @@ RSpec.describe Filterameter::Filters::ConditionalScopeFilter do
       )
     end
   end
+
+  context 'with converter' do
+    let(:filter) { described_class.new(:incomplete) { |v| v == 'YES' } }
+
+    it 'applies converter to value' do
+      filter.apply(query, 'YES')
+      expect(query).to have_received(:incomplete)
+    end
+
+    it 'does not apply filter when converter returns false' do
+      filter.apply(query, 'NO')
+      expect(query).not_to have_received(:incomplete)
+    end
+  end
 end

--- a/spec/filterameter/filters/matches_filter_spec.rb
+++ b/spec/filterameter/filters/matches_filter_spec.rb
@@ -63,4 +63,12 @@ RSpec.describe Filterameter::Filters::MatchesFilter do
       expect(filter.valid?(Activity)).to be false
     end
   end
+
+  context 'with converter' do
+    let(:filter) { described_class.new(:name, options, &:upcase) }
+
+    it 'applies converter to value' do
+      expect(query.to_sql).to match(/PREPARE/)
+    end
+  end
 end

--- a/spec/filterameter/filters/maximum_filter_spec.rb
+++ b/spec/filterameter/filters/maximum_filter_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe Filterameter::Filters::MaximumFilter do
       expect(filter.valid?(Activity)).to be false
     end
   end
+
+  context 'with converter' do
+    let(:filter) { described_class.new(Activity, :task_count) { |v| v.is_a?(String) ? v.delete(',') : v } }
+    let(:query) { filter.apply(Activity.all, '1,234') }
+
+    it 'converts value' do
+      expect(query.to_sql).to include '<= 1234'
+    end
+  end
 end

--- a/spec/filterameter/filters/minimum_filter_spec.rb
+++ b/spec/filterameter/filters/minimum_filter_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe Filterameter::Filters::MinimumFilter do
       expect(filter.valid?(Activity)).to be false
     end
   end
+
+  context 'with converter' do
+    let(:filter) { described_class.new(Activity, :task_count) { |v| v.is_a?(String) ? v.delete(',') : v } }
+    let(:query) { filter.apply(Activity.all, '1,234') }
+
+    it 'converts value' do
+      expect(query.to_sql).to include '>= 1234'
+    end
+  end
 end

--- a/spec/filterameter/filters/scope_filter_spec.rb
+++ b/spec/filterameter/filters/scope_filter_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe Filterameter::Filters::ScopeFilter do
       )
     end
   end
+
+  context 'with a converter' do
+    let(:filter) { described_class.new(:in_progress) { |v| v == 'TOTALLY' } }
+
+    it 'applies converter to value' do
+      filter.apply(query, 'TOTALLY')
+      expect(query).to have_received(:in_progress).with(true)
+    end
+  end
 end

--- a/spec/requests/attribute_filters_spec.rb
+++ b/spec/requests/attribute_filters_spec.rb
@@ -85,8 +85,46 @@ RSpec.describe 'Attribute filters' do
     end
   end
 
+  context 'with boolean filter and value converted to true' do
+    before { get '/tasks', params: { filter: { yes_no_completed: 'YES' } } }
+
+    it 'returns the correct number of rows' do
+      count = Task.where(completed: true).count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'returns Grind coffee beans' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('description' => tasks(:grind_coffee_beans).description)
+    end
+
+    it 'does not return Make toast' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).not_to include_a_record_with('description' => tasks(:make_toast).description)
+    end
+  end
+
   context 'with boolean filter set to false' do
     before { get '/tasks', params: { filter: { completed: false } } }
+
+    it 'returns the correct number of rows' do
+      count = Task.where(completed: false).count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'does not return Grind coffee beans' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).not_to include_a_record_with('description' => tasks(:grind_coffee_beans).description)
+    end
+
+    it 'returns Make toast' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('description' => tasks(:make_toast).description)
+    end
+  end
+
+  context 'with boolean filter and value converted to false' do
+    before { get '/tasks', params: { filter: { yes_no_completed: 'NOPE' } } }
 
     it 'returns the correct number of rows' do
       count = Task.where(completed: false).count

--- a/spec/requests/range_filters_spec.rb
+++ b/spec/requests/range_filters_spec.rb
@@ -99,4 +99,17 @@ RSpec.describe 'Range filters' do
       end
     end
   end
+
+  context 'with converter' do
+    it 'returns no rows (for min 1,000)' do
+      get '/activities', params: { filter: { task_count_with_comma_min: '1,000' } }
+      expect(response.parsed_body.size).to eq 0
+    end
+
+    it 'returns all rows (for max 1,000)' do
+      get '/activities', params: { filter: { task_count_with_comma_max: '1,000' } }
+      count = Activity.where('task_count <= 1000').count
+      expect(response.parsed_body.size).to eq count
+    end
+  end
 end

--- a/spec/requests/scope_filters_spec.rb
+++ b/spec/requests/scope_filters_spec.rb
@@ -27,6 +27,29 @@ RSpec.describe 'Scope filters' do
       end
     end
 
+    context 'with converter and true' do
+      before { get '/activities', params: { filter: { yes_no_incomplete: 'YES' } } }
+
+      it 'returns the correct number of rows' do
+        count = Activity.where(completed: false).count
+        expect(response.parsed_body.size).to eq count
+      end
+
+      it 'returns Have a good breakfast' do
+        expect(response).to have_http_status(:success)
+        expect(response.parsed_body).to include_a_record_with('name' => activities(:good_breakfast).name)
+      end
+    end
+
+    context 'with converter and false' do
+      before { get '/activities', params: { filter: { yes_no_incomplete: 'NO' } } }
+
+      it 'does not apply the scope' do
+        count = Activity.count
+        expect(response.parsed_body.size).to eq count
+      end
+    end
+
     context 'with name specified' do
       before { get '/activities', params: { filter: { in_progress: true } } }
 
@@ -62,6 +85,20 @@ RSpec.describe 'Scope filters' do
     it 'returns Start day on the right foot' do
       expect(response).to have_http_status(:success)
       expect(response.parsed_body).to include_a_record_with('name' => projects(:start_day).name)
+    end
+  end
+
+  context 'with arguments and converter' do
+    before { get '/projects', params: { filter: { in_progress_as_of_days_ago: 10 } } }
+
+    it 'returns the correct number of rows' do
+      count = Project.in_progress(10.days.ago).count
+      expect(response.parsed_body.size).to eq count
+    end
+
+    it 'returns "Read a book"' do
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body).to include_a_record_with('name' => projects(:read_a_book).name)
     end
   end
 end


### PR DESCRIPTION
If the filter value needs to be converted before being applied to the query, a converter block can be provided. The block should take the parameter value as an argument and return the converted value.

For example, if the amount filter should remove commas from the value before applying it to the query, the declaration would look like this:

```ruby
filter :amount do |value|
  value.is_a?(String) ? value.delete(",") : value
end
```
